### PR TITLE
Str expansion

### DIFF
--- a/makefile
+++ b/makefile
@@ -95,10 +95,12 @@ unity_debug:
 ud:
 	make unity_debug
 
+# TODO: finish impl
 # Unity/jumbo debug build, with history, z database, rc file in place
 in_place_debug:
 	$(CC) $(STD) $(debug_flags) -DNCSH_IN_PLACE src/unity.c -o $(target)
 
+# TODO: finish impl
 # Unity/jumbo release build, with history, z database, rc file in place
 in_place_release:
 	$(CC) $(STD) $(release_flags) -DNCSH_IN_PLACE src/unity.c -o $(target)

--- a/src/alias.h
+++ b/src/alias.h
@@ -13,23 +13,23 @@ typedef struct {
 /* alias_check
  * Return the actual command for input if it is an alias.
  */
-Str alias_check(char* restrict buffer, size_t len);
+Str alias_check(Str alias);
 
 /* alias_add
  * Add an alias from a line read from .ncshrc config file.
  * val is in form "cmd=command".
  */
-void alias_add(char* restrict val, size_t len, Arena* restrict arena);
+void alias_add(Str alias, Arena* restrict arena);
 
 /* alias_add_new
  * Add an alias and its command value.
  */
-void alias_add_new(char* restrict alias, size_t a_len, char* restrict command, size_t c_len, Arena* restrict arena);
+void alias_add_new(Str alias, Str command, Arena* restrict arena);
 
 /* alias_remove
  * Remove an alias if it exists
  */
-void alias_remove(char* restrict val, size_t len);
+void alias_remove(Str alias);
 
 /* alias_delete
  * Delete all aliases.

--- a/src/arena.c
+++ b/src/arena.c
@@ -1,6 +1,6 @@
 /* Copyright ncsh (C) by Alex Eski 2025 */
 /* arena.h: a simple bump allocator for managing memory */
-/* Credit to skeeto and his blogs */
+/* Credit to skeeto and his blogs for inspiration */
 
 #include <assert.h>
 #include <stddef.h>
@@ -31,10 +31,9 @@ ATTR_ALLOC_ALIGN(4)
 void* arena_malloc__(Arena* restrict arena, uintptr_t count, uintptr_t size,
                             uintptr_t alignment)
 {
-    assert(arena && count && size && alignment);
+    assert(arena); assert(count); assert(size); assert(alignment);
     uintptr_t padding = -(uintptr_t)arena->start & (alignment - 1);
     uintptr_t available = (uintptr_t)arena->end - (uintptr_t)arena->start - padding;
-    // debugf("arena space avaiable %zu\n", available);
     assert(count < available / size);
     if (available == 0 || count > available / size) {
         arena_abort_fn__();
@@ -50,16 +49,10 @@ ATTR_ALLOC_ALIGN(4)
 void* arena_realloc__(Arena* restrict arena, uintptr_t count, uintptr_t size,
                                                   uintptr_t alignment, void* old_ptr, uintptr_t old_count)
 {
-    assert(arena);
-    assert(count);
-    assert(size);
-    assert(alignment);
-    assert(old_ptr);
-    assert(old_count);
+    assert(arena); assert(count); assert(size); assert(alignment); assert(old_ptr); assert(old_count);
 
     uintptr_t padding = -(uintptr_t)arena->start & (alignment - 1);
     uintptr_t available = (uintptr_t)arena->end - (uintptr_t)arena->start - padding;
-    // debugf("arena space avaiable %zu\n", available);
     assert(count < available / size);
     if (available == 0 || count > available / size) {
         arena_abort_fn__();
@@ -67,6 +60,5 @@ void* arena_realloc__(Arena* restrict arena, uintptr_t count, uintptr_t size,
     void* val = arena->start + padding;
     arena->start += padding + count * size;
     memset(val, 0, count * size);
-    assert(old_ptr);
     return memcpy(val, old_ptr, old_count * size);
 }

--- a/src/arena.h
+++ b/src/arena.h
@@ -30,6 +30,7 @@ typedef struct {
 
 /* arena_abort_fn_set
  * Set the function to be called if the arena is full and the requested memory can't be allocated in the arena.
+ * abort_func should call exit, abort, or longjmp.
  */
 void arena_abort_fn_set(void (*abort_func)());
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -35,105 +35,45 @@ enum eresult conf_location_init(Shell* restrict shell)
         return E_FAILURE_NULL_REFERENCE;
     }
 
-    shell->config.location.value = arena_malloc(&shell->arena, NCSH_MAX_INPUT, char);
-
-    char* conf_original_ptr = shell->config.location.value;
     Str* home = env_home_get(shell->env);
-    assert(home && home->value);
-    shell->config.location.length = home->length - 1;
 
-    constexpr size_t location_len = sizeof(DOT_CONFIG) + sizeof(NCSH);
-    constexpr size_t location_folder_len = 1 + location_len + 1;
-    if (shell->config.location.length + location_folder_len > NCSH_MAX_INPUT) {
+    constexpr size_t location_len = sizeof(DOT_CONFIG) + sizeof(NCSH) + 1 + 1;
+    if (home->length + location_len > PATH_MAX) {
         shell->config.location.value[0] = '\0';
         return E_FAILURE_OVERFLOW_PROTECTION;
     }
 
-    memcpy(shell->config.location.value, home->value, home->length - 1);
-    shell->config.location.value += home->length - 1;
-    *shell->config.location.value = '/';
-    ++shell->config.location.length;
-    ++shell->config.location.value;
-    memcpy(shell->config.location.value, DOT_CONFIG "/" NCSH, location_len);
-    shell->config.location.value += location_len;
-    *shell->config.location.value = '\0';
-    shell->config.location.length += location_len;
-    shell->config.location.value = (char*)conf_original_ptr;
-
-    debugf("shell->config.location.value: %s\n", shell->config.location.value);
-    assert(strlen(shell->config.location.value) + 1 == shell->config.location.length);
+    shell->config.location = *estrjoin(home, &Str_New_Literal(DOT_CONFIG "/" NCSH), '/', &shell->arena);
     mkdir(shell->config.location.value, 0755);
 
+    debugf("config location: %s\n", shell->config.location.value);
     return E_SUCCESS;
 }
 
 [[nodiscard]]
 enum eresult conf_file_set(Shell* restrict shell)
 {
-    constexpr size_t rc_len = sizeof(RC_FILE);
-    constexpr size_t rc_len_nt = rc_len - 1;
 
+    Str rc_file = Str_New_Literal(RC_FILE);
 #if defined(NCSH_IN_PLACE)
-    shell->config.file.value = arena_malloc(arena, rc_len, char);
-    memcpy(shell->config.file.value, RC_FILE, rc_len_nt);
-    shell->config.file.value[rc_len_nt] = '\0';
-    shell->config.file.length = rc_len;
+    shell->config.file = *estrdup(&rc_file, &shell->arena);
     return E_SUCCESS;
 #endif
 
     if (!shell->config.location.value || !shell->config.location.length) {
-        shell->config.file.value = arena_malloc(&shell->arena, rc_len, char);
-        memcpy(shell->config.file.value, RC_FILE, rc_len_nt);
-        shell->config.file.value[rc_len_nt] = '\0';
-        shell->config.file.length = rc_len;
-
+        shell->config.file = *estrdup(&rc_file, &shell->arena);
         return E_SUCCESS;
     }
 
-    if (shell->config.location.length + rc_len > NCSH_MAX_INPUT) {
+    if (shell->config.location.length + rc_file.length > NCSH_MAX_INPUT) {
         shell->config.file.value = NULL;
         return E_FAILURE_OVERFLOW_PROTECTION;
     }
 
-    shell->config.file.value =
-        arena_malloc(&shell->arena, shell->config.location.length + rc_len, char);
-    memcpy(shell->config.file.value,
-           shell->config.location.value,
-           shell->config.location.length - 1);
-    memcpy(shell->config.file.value + shell->config.location.length - 1,"/" RC_FILE, rc_len);
-    shell->config.file.length =
-        shell->config.location.length + rc_len;
-    shell->config.file.value[shell->config.file.length - 1] = '\0';
-    debugf("file %s\n", shell->config.file.value);
+    shell->config.file = *estrjoin(&shell->config.location, &rc_file, '/', &shell->arena);
 
+    debugf("config file %s\n", shell->config.file.value);
     return E_SUCCESS;
-}
-
-/* conf_path_add
- * The function which handles config items which add values to PATH.
- */
-#define PATH "PATH"
-#define PATH_ADD "PATH+="
-
-void conf_path_add(Str* path, char* restrict val, int len, Arena* restrict arena)
-{
-    assert(val);
-    assert(len > 0);
-    if (len <= 0 || !path->length) {
-        return;
-    }
-
-    assert(!val[len - 1]);
-    debugf("trying to add %s to path\n", val);
-
-    Str new_path = {.length = path->length + (size_t)len};
-    new_path.value = arena_realloc(arena, new_path.length, char, path->value, path->length);
-    memcpy(new_path.value, path->value, path->length - 1);
-    new_path.value[path->length - 1] = ':';
-    memcpy(new_path.value + path->length, val, (size_t)len);
-    path->value = new_path.value;
-    path->length = new_path.length;
-    debugf("Got new path to set %s\n", new_path.value);
 }
 
 /* conf_process
@@ -141,21 +81,21 @@ void conf_path_add(Str* path, char* restrict val, int len, Arena* restrict arena
  */
 #define PATH_ADD "PATH+="
 #define ALIAS_ADD "ALIAS "
-void conf_process(FILE* restrict file, Shell* shell)
+void conf_process(FILE* restrict file, Shell* restrict shell, Arena* restrict scratch)
 {
     int buffer_length;
     char buffer[NCSH_MAX_INPUT] = {0};
-    bool update_path = false;
     Str path_key = Str_New_Literal(NCSH_PATH_VAL);
     Str* path = env_add_or_get(shell->env, path_key);
+    Str_Builder* sb = sb_new(scratch);
+    sb_add(path, sb, scratch);
 
     while ((buffer_length = efgets(buffer, sizeof(buffer), file)) != EOF) {
         // Add to path (6 because PATH+=)
         if (buffer_length > 6 && !memcmp(buffer, PATH_ADD, sizeof(PATH_ADD) - 1)) {
             assert(buffer + 6 && *(buffer + 6));
             debugf("adding to PATH: %s\n", buffer + 6);
-            conf_path_add(path, buffer + 6, buffer_length - 6, &shell->arena);
-            update_path = true;
+            sb_add(&Str_New(buffer + 6, (size_t)(buffer_length - 6)), sb, scratch);
         }
         // Aliasing (aliased=alias)
         else if (buffer_length > 6 && !memcmp(buffer, ALIAS_ADD, sizeof(ALIAS_ADD) - 1)) {
@@ -166,8 +106,9 @@ void conf_process(FILE* restrict file, Shell* shell)
         memset(buffer, '\0', (size_t)buffer_length);
     }
 
-    if (path->length && update_path) {
-        setenv(PATH, path->value, true);
+    if (sb->n > 1) {
+        *path = *sb_to_joined_str(sb, ':', &shell->arena);
+        setenv(NCSH_PATH_VAL, path->value, true);
     }
 }
 
@@ -176,7 +117,7 @@ void conf_process(FILE* restrict file, Shell* shell)
  * Returns: enum eresult, E_SUCCESS if config file loaded or user doesn't want one.
  */
 [[nodiscard]]
-enum eresult conf_file_load(Shell* shell)
+enum eresult conf_file_load(Shell* restrict shell, Arena* restrict scratch)
 {
     FILE* file = fopen(shell->config.file.value, "r");
     if (!file || ferror(file) || feof(file)) {
@@ -209,7 +150,7 @@ enum eresult conf_file_load(Shell* shell)
         return E_SUCCESS;
     }
 
-    conf_process(file, shell);
+    conf_process(file, shell, scratch);
 
     fclose(file);
     return E_SUCCESS;
@@ -221,9 +162,9 @@ enum eresult conf_file_load(Shell* shell)
  * Returns: enum eresult, E_SUCCESS is successful
  */
 [[nodiscard]]
-enum eresult conf_init(Shell* shell)
+enum eresult conf_init(Shell* restrict shell, Arena scratch)
 {
-    assert(shell && shell->arena.start);
+    assert(shell); assert(shell->arena.start);
 
     enum eresult result;
     if ((result = conf_location_init(shell)) != E_SUCCESS) {
@@ -236,7 +177,7 @@ enum eresult conf_init(Shell* shell)
         return result;
     }
 
-    if ((result = conf_file_load(shell)) != E_SUCCESS) {
+    if ((result = conf_file_load(shell, &scratch)) != E_SUCCESS) {
         debug("failed loading config file");
         return result;
     }

--- a/src/conf.c
+++ b/src/conf.c
@@ -160,7 +160,7 @@ void conf_process(FILE* restrict file, Shell* shell)
         // Aliasing (aliased=alias)
         else if (buffer_length > 6 && !memcmp(buffer, ALIAS_ADD, sizeof(ALIAS_ADD) - 1)) {
             assert(buffer + 6 && *(buffer + 6));
-            alias_add(buffer + 6, (size_t)(buffer_length - 6), &shell->arena);
+            alias_add(Str_New(buffer + 6, (size_t)(buffer_length - 6)), &shell->arena);
         }
 
         memset(buffer, '\0', (size_t)buffer_length);

--- a/src/conf.h
+++ b/src/conf.h
@@ -10,4 +10,4 @@
 #define DOT_CONFIG ".config"
 #define RC_FILE "ncshrc"
 
-enum eresult conf_init(Shell* shell);
+enum eresult conf_init(Shell* shell, Arena scratch);

--- a/src/configurables.h
+++ b/src/configurables.h
@@ -116,7 +116,7 @@
  * The max input for reading in a line. Relevant to ncsh_readline when processing user input.
  */
 #ifndef NCSH_MAX_INPUT
-#define    NCSH_MAX_INPUT 1024
+#define    NCSH_MAX_INPUT 2048
 #endif // !NCSH_MAX_INPUT
 
 // clang-format on

--- a/src/debug.h
+++ b/src/debug.h
@@ -21,22 +21,22 @@
 #include "eskilib/str.h"
 #include "interpreter/lexer.h"
 
-#define debug(buf) debug_internal(__FILE__, __LINE__, __func__, buf)
-#define debugf(fmt, ...) debugf_internal(__FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__)
-#define debug_line(buf, len, max_len) debug_line_internal(__FILE__, __LINE__, __func__, buf, len, max_len)
-#define debug_lexer_input(buf, len) debug_lexer_input_internal(__FILE__, __LINE__, __func__, buf, len)
-#define debug_lexemes(lexemes) debug_lexemes_internal(__FILE__, __LINE__, __func__, lexemes)
-#define debug_argsv(argsc, argsv) debug_argsv_internal(__FILE__, __LINE__, __func__, argsc, argsv)
-#define debug_string(str, name) debug_string_internal(__FILE__, __LINE__, __func__, str, name)
+#define debug(buf) debug__(__FILE__, __LINE__, __func__, buf)
+#define debugf(fmt, ...) debugf__(__FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__)
+#define debug_line(buf, len, max_len) debug_line__(__FILE__, __LINE__, __func__, buf, len, max_len)
+#define debug_lexer_input(buf, len) debug_lexer_input__(__FILE__, __LINE__, __func__, buf, len)
+#define debug_lexemes(lexemes) debug_lexemes__(__FILE__, __LINE__, __func__, lexemes)
+#define debug_argsv(argsc, argsv) debug_argsv__(__FILE__, __LINE__, __func__, argsc, argsv)
+#define debug_string(str, name) debug_string__(__FILE__, __LINE__, __func__, str, name)
 
-static inline void debug_internal(const char* file, const int line, const char* func, char* buffer)
+static inline void debug__(const char* file, const int line, const char* func, char* buffer)
 {
     fprintf(stderr, "%s %s:%d ", file, func, line);
     fprintf(stderr, "%s\n", buffer);
     fflush(stderr);
 }
 
-static inline void debugf_internal(const char* file, const int line, const char* func, char* fmt, ...)
+static inline void debugf__(const char* file, const int line, const char* func, char* fmt, ...)
 {
     va_list args;
     va_start(args, format);
@@ -46,7 +46,7 @@ static inline void debugf_internal(const char* file, const int line, const char*
     fflush(stderr);
 }
 
-static inline void debug_line_internal(const char* file, const int line, const char* func, char* buffer,
+static inline void debug_line__(const char* file, const int line, const char* func, char* buffer,
                                        size_t buf_position, size_t max_buf_position)
 {
     fprintf(stderr, "%s %s:%d ", file, func, line);
@@ -58,7 +58,7 @@ static inline void debug_line_internal(const char* file, const int line, const c
     fflush(stderr);
 }
 
-static inline void debug_lexer_input_internal(const char* file, const int line, const char* func, char* buffer,
+static inline void debug_lexer_input__(const char* file, const int line, const char* func, char* buffer,
                                               size_t buf_position)
 {
     fprintf(stderr, "%s %s:%d ", file, func, line);
@@ -68,7 +68,7 @@ static inline void debug_lexer_input_internal(const char* file, const int line, 
     fflush(stderr);
 }
 
-static inline void debug_lexemes_internal(const char* file, const int line, const char* func, Lexemes* lexemes)
+static inline void debug_lexemes__(const char* file, const int line, const char* func, Lexemes* lexemes)
 {
     fprintf(stderr, "%s %s:%d ", file, func, line);
     fprintf(stderr, "lexemes->count: %lu\n", lexemes->count);
@@ -84,7 +84,7 @@ static inline void debug_lexemes_internal(const char* file, const int line, cons
     fflush(stderr);
 }
 
-static inline void debug_argsv_internal(const char* file, const int line, const char* func, int argc, char** argv)
+static inline void debug_argsv__(const char* file, const int line, const char* func, int argc, char** argv)
 {
     for (int i = 0; i < argc; ++i) {
         fprintf(stderr, "%s %s:%d ", file, func, line);
@@ -93,7 +93,7 @@ static inline void debug_argsv_internal(const char* file, const int line, const 
     fflush(stderr);
 }
 
-static inline void debug_string_internal(const char* file, const int line, const char* func, Str string, char* name)
+static inline void debug_string__(const char* file, const int line, const char* func, Str string, char* name)
 {
     fprintf(stderr, "%s %s:%d ", file, func, line);
     fprintf(stderr, "%s value: %s\n", name, string.value);

--- a/src/defines.h
+++ b/src/defines.h
@@ -10,7 +10,7 @@
 
 // clang-format off
 
-#define NCSH_VERSION "0.0.5.12"
+#define NCSH_VERSION "0.0.5.13"
 
 /* EXIT_* Constants
  * Exit values used by a multitude of functions and areas in the shell.

--- a/src/env.c
+++ b/src/env.c
@@ -74,9 +74,9 @@ Str* env_home_get(Env* env)
     assert(env);
 
     Str xdg_config_home_key = Str_New_Literal(NCSH_XDG_CONFIG_HOME_VAL);
-
     Str* home = env_add_or_get(env, xdg_config_home_key);
     debugf("%s? %s\n", NCSH_XDG_CONFIG_HOME_VAL, home->value);
+
     if (!home || !home->value) {
         Str home_key = Str_New_Literal(NCSH_HOME_VAL);
         home = env_add_or_get(env, home_key);

--- a/src/env.c
+++ b/src/env.c
@@ -63,7 +63,7 @@ Str* env_add_or_get(Env* env, Str key)
             env->keys[i] = key;
             return env->vals + i;
         }
-        else if (estrcmp_s(env->keys[i], key)) {
+        else if (estrcmp(env->keys[i], key)) {
             return env->vals + i;
         }
     }
@@ -74,11 +74,11 @@ Str* env_home_get(Env* env)
     assert(env);
 
     Str xdg_config_home_key = Str_New_Literal(NCSH_XDG_CONFIG_HOME_VAL);
-    Str home_key = Str_New_Literal(NCSH_HOME_VAL);
 
     Str* home = env_add_or_get(env, xdg_config_home_key);
     debugf("%s? %s\n", NCSH_XDG_CONFIG_HOME_VAL, home->value);
     if (!home || !home->value) {
+        Str home_key = Str_New_Literal(NCSH_HOME_VAL);
         home = env_add_or_get(env, home_key);
         debugf("HOME? %s\n", home->value);
     }

--- a/src/eskilib/str.h
+++ b/src/eskilib/str.h
@@ -40,7 +40,17 @@ typedef struct {
 /* estrcmp
  * A simple wrapper for memcmp that checks if lengths match before calling memcmp.
  */
-enodiscard static inline bool estrcmp(char* restrict str, size_t str_len, char* restrict str_two, size_t str_two_len)
+enodiscard static inline bool estrcmp(Str v, Str v2)
+{
+    if (v.length != v2.length || !v.length) {
+        return false;
+    }
+
+    return !v.value || !memcmp(v.value, v2.value, v.length);
+}
+
+
+enodiscard static inline bool estrcmp_a(char* restrict str, size_t str_len, char* restrict str_two, size_t str_two_len)
 {
     if (str_len != str_two_len || !str_len) {
         return false;
@@ -49,13 +59,13 @@ enodiscard static inline bool estrcmp(char* restrict str, size_t str_len, char* 
     return !str || !memcmp(str, str_two, str_len);
 }
 
-enodiscard static inline bool estrcmp_s(Str val, Str val2)
+enodiscard static inline bool estrcmp_s(Str v, char* restrict v2, size_t v2_len)
 {
-    if (val.length != val2.length || !val.length) {
+    if (v.length != v2_len || !v.length) {
         return false;
     }
 
-    return !val.value || !memcmp(val.value, val2.value, val.length);
+    return !v.value || !memcmp(v.value, v2, v.length);
 }
 
 /* estrsplit
@@ -145,6 +155,15 @@ enodiscard static inline size_t estridx(Str* v, char c)
             break;
     }
     return idx;
+}
+
+enodiscard static inline char** estrtoarr(Str* strs, size_t n, Arena* restrict a)
+{
+    char** buffer = arena_malloc(a, n, char*);
+    for (size_t i = 0; i < n; ++i) {
+        buffer[i] = strs[i].value;
+    }
+    return buffer;
 }
 
 static inline void estrtrim(Str* v)

--- a/src/interpreter/builtins.c
+++ b/src/interpreter/builtins.c
@@ -622,7 +622,7 @@ static int builtins_pwd([[maybe_unused]] Str* restrict strs)
 static int builtins_kill(Str* restrict strs)
 {
     assert(strs);
-    if (!strs || !strs->value || !strs->value[1]) {
+    if (!strs || !strs->value) {
         if (builtins_writeln(vm_output_fd, KILL_NOTHING_TO_KILL_MESSAGE, sizeof(KILL_NOTHING_TO_KILL_MESSAGE) - 1) ==
             -1) {
             return EXIT_FAILURE;
@@ -633,6 +633,14 @@ static int builtins_kill(Str* restrict strs)
 
     // skip first position since we know it is 'kill'
     Str* args = strs + 1;
+    if (!args || !args->value) {
+        if (builtins_writeln(vm_output_fd, KILL_NOTHING_TO_KILL_MESSAGE, sizeof(KILL_NOTHING_TO_KILL_MESSAGE) - 1) ==
+            -1) {
+            return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+    }
 
     pid_t pid = atoi(args->value);
     if (!pid) {

--- a/src/interpreter/builtins.c
+++ b/src/interpreter/builtins.c
@@ -297,20 +297,12 @@ static int builtins_history(History* restrict history, Str* restrict strs, Arena
     if (args && args[1].value && !args[2].value) {
         // history add
         if (estrcmp(*args, Str_New_Literal(NCSH_HISTORY_ADD))) {
-            if (history_command_add(args[1], history, arena) != EXIT_SUCCESS) {
-                return EXIT_FAILURE_CONTINUE;
-            }
-
-            return EXIT_SUCCESS;
+            return history_command_add(args[1], history, arena);
         }
         // history rm/remove
         else if (estrcmp(*args, Str_New_Literal(NCSH_HISTORY_RM)) ||
                  estrcmp(*args, Str_New_Literal(NCSH_HISTORY_REMOVE))) {
-            if (history_command_remove(args[1], history, arena, scratch) != EXIT_SUCCESS) {
-                return EXIT_FAILURE_CONTINUE;
-            }
-
-            return EXIT_SUCCESS;
+            return history_command_remove(args[1], history, arena, scratch);
         }
     }
 

--- a/src/interpreter/builtins.c
+++ b/src/interpreter/builtins.c
@@ -72,7 +72,7 @@ static int builtins_writeln(int fd, char* buf, size_t len)
 #define Z_REMOVE "remove" // alias for rm
 #define Z_PRINT "print"
 #define Z_COUNT "count"
-static int builtins_z(z_Database* restrict z_db, char** restrict buffer, size_t* restrict buf_lens, Arena* arena, Arena* restrict scratch);
+static int builtins_z(z_Database* restrict z_db, Str* restrict strs, Arena* arena, Arena* restrict scratch);
 
 #define NCSH_HISTORY "history" // the base command, displays history
 #define NCSH_HISTORY_COUNT "count"
@@ -80,7 +80,7 @@ static int builtins_z(z_Database* restrict z_db, char** restrict buffer, size_t*
 #define NCSH_HISTORY_ADD "add"
 #define NCSH_HISTORY_RM "rm" // alias for rm
 #define NCSH_HISTORY_REMOVE "remove"
-static int builtins_history(History* restrict history, char** restrict buffer, size_t* restrict buf_lens, Arena* restrict arena,
+static int builtins_history(History* restrict history, Str* restrict strs, Arena* restrict arena,
                      Arena* restrict scratch);
 
 #define NCSH_ALIAS "alias"
@@ -90,58 +90,58 @@ static int builtins_history(History* restrict history, char** restrict buffer, s
 #define NCSH_ALIAS_RM "rm"
 #define NCSH_ALIAS_REMOVE "remove"
 #define NCSH_ALIAS_DELETE "delete"
-static int builtins_alias(char** restrict buffer, size_t* restrict buf_lens, Arena* restrict arena);
+static int builtins_alias(Str* restrict strs, Arena* restrict arena);
 
 #define NCSH_UNALIAS "unalias"
 #define NCSH_UNALIAS_DELETE "-a"
 #define NCSH_UNALIAS_DELETE_ALIAS "delete"
-static int builtins_unalias(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_unalias(Str* restrict strs);
 
 #define NCSH_EXIT "exit" // the base command
 #define NCSH_QUIT "quit" // alias for exit
 #define NCSH_Q "q"       // alias for exit
-static int builtins_exit(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_exit(Str* restrict strs);
 
 #define NCSH_ECHO "echo"
 #define NCSH_ECHO_NO_NEWLINE "-n"
-static int builtins_echo(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_echo(Str* restrict strs);
 
 #define NCSH_HELP "help"
-static int builtins_help(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_help(Str* restrict strs);
 
 #define NCSH_CD "cd"
-static int builtins_cd(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_cd(Str* restrict strs);
 
 #define NCSH_PWD "pwd"
-static int builtins_pwd(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_pwd(Str* restrict strs);
 
 #define NCSH_KILL "kill"
-static int builtins_kill(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_kill(Str* restrict strs);
 
 #define NCSH_VERSION_CMD "version"
-static int builtins_version(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_version(Str* restrict strs);
 
 #define NCSH_TRUE "true"
-static int builtins_true(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_true(Str* restrict strs);
 
 #define NCSH_FALSE "false"
-static int builtins_false(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_false(Str* restrict strs);
 
 #define NCSH_ENABLE "enable"
-static int builtins_enable(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_enable(Str* restrict strs);
 
 #define NCSH_DISABLE "disable"
-static int builtins_disable(char** restrict buffer, size_t* restrict buf_lens);
+static int builtins_disable(Str* restrict strs);
 
 // TODO: finish implementation
 // #define NCSH_EXPORT "export"
 // int builtins_export(Statements* restrict toks, size_t* restrict buf_lens);
 
 // #define NCSH_SET "set"
-// static int builtins_set(char** restrict buffer, size_t* restrict buf_lens, Env* restrict env);
+// static int builtins_set(Str* restrict strs, Env* restrict env);
 
 #define NCSH_UNSET "unset"
-static int builtins_unset(char** restrict buffer, size_t* restrict buf_lens, Env* restrict env);
+static int builtins_unset(Str* restrict strs, Env* restrict env);
 
 /* Types */
 // clang-format off
@@ -170,29 +170,28 @@ enum Builtins_Disabled : long unsigned int {
 
 typedef struct {
     enum Builtins_Disabled flag;
-    size_t length;
-    char* value;
-    int (*func)(char** restrict r, size_t* restrict l);
+    Str str;
+    int (*func)(Str* restrict strs);
 } Builtin;
 
 static const Builtin builtins[] = {
-    {.flag = BF_EXIT, .length = sizeof(NCSH_EXIT), .value = NCSH_EXIT, .func = &builtins_exit},
-    {.flag = BF_EXIT, .length = sizeof(NCSH_QUIT), .value = NCSH_QUIT, .func = &builtins_exit},
-    {.flag = BF_EXIT, .length = sizeof(NCSH_Q), .value = NCSH_Q, .func = &builtins_exit},
-    {.flag = BF_ECHO, .length = sizeof(NCSH_ECHO), .value = NCSH_ECHO, .func = &builtins_echo},
-    {.flag = BF_HELP, .length = sizeof(NCSH_HELP), .value = NCSH_HELP, .func = &builtins_help},
-    {.flag = BF_CD, .length = sizeof(NCSH_CD), .value = NCSH_CD, .func = &builtins_cd},
-    {.flag = BF_PWD, .length = sizeof(NCSH_PWD), .value = NCSH_PWD, .func = &builtins_pwd},
-    {.flag = BF_KILL, .length = sizeof(NCSH_KILL), .value = NCSH_KILL, .func = &builtins_kill},
-    {.flag = BF_VERSION, .length = sizeof(NCSH_VERSION_CMD), .value = NCSH_VERSION_CMD, .func = &builtins_version},
-    {.flag = BF_UNALIAS, .length = sizeof(NCSH_UNALIAS), .value = NCSH_UNALIAS, .func = &builtins_unalias},
-    {.flag = BF_TRUE, .length = sizeof(NCSH_TRUE), .value = NCSH_TRUE, .func = &builtins_true},
-    {.flag = BF_FALSE, .length = sizeof(NCSH_FALSE), .value = NCSH_FALSE, .func = &builtins_false},
-    {.flag = BF_ENABLE, .length = sizeof(NCSH_ENABLE), .value = NCSH_ENABLE, .func = &builtins_enable},
-    {.flag = BF_DISABLE, .length = sizeof(NCSH_DISABLE), .value = NCSH_DISABLE, .func = &builtins_disable},
-    /*{.flag = BF_EXPORT, .length = sizeof(NCSH_EXPORT), .value = NCSH_EXPORT, .func = &builtins_export},
-    {.flag = BF_SET, .length = sizeof(NCSH_SET), .value = NCSH_SET, .func = &builtins_set},
-    {.flag = BF_UNSET, .length = sizeof(NCSH_UNSET), .value = NCSH_UNSET, .func = &builtins_unset},*/
+    {.flag = BF_EXIT, .str.length = sizeof(NCSH_EXIT), .str.value = NCSH_EXIT, .func = &builtins_exit},
+    {.flag = BF_EXIT, .str.length = sizeof(NCSH_QUIT), .str.value = NCSH_QUIT, .func = &builtins_exit},
+    {.flag = BF_EXIT, .str.length = sizeof(NCSH_Q), .str.value = NCSH_Q, .func = &builtins_exit},
+    {.flag = BF_ECHO, .str.length = sizeof(NCSH_ECHO), .str.value = NCSH_ECHO, .func = &builtins_echo},
+    {.flag = BF_HELP, .str.length = sizeof(NCSH_HELP), .str.value = NCSH_HELP, .func = &builtins_help},
+    {.flag = BF_CD, .str.length = sizeof(NCSH_CD), .str.value = NCSH_CD, .func = &builtins_cd},
+    {.flag = BF_PWD, .str.length = sizeof(NCSH_PWD), .str.value = NCSH_PWD, .func = &builtins_pwd},
+    {.flag = BF_KILL, .str.length = sizeof(NCSH_KILL), .str.value = NCSH_KILL, .func = &builtins_kill},
+    {.flag = BF_VERSION, .str.length = sizeof(NCSH_VERSION_CMD), .str.value = NCSH_VERSION_CMD, .func = &builtins_version},
+    {.flag = BF_UNALIAS, .str.length = sizeof(NCSH_UNALIAS), .str.value = NCSH_UNALIAS, .func = &builtins_unalias},
+    {.flag = BF_TRUE, .str.length = sizeof(NCSH_TRUE), .str.value = NCSH_TRUE, .func = &builtins_true},
+    {.flag = BF_FALSE, .str.length = sizeof(NCSH_FALSE), .str.value = NCSH_FALSE, .func = &builtins_false},
+    {.flag = BF_ENABLE, .str.length = sizeof(NCSH_ENABLE), .str.value = NCSH_ENABLE, .func = &builtins_enable},
+    {.flag = BF_DISABLE, .str.length = sizeof(NCSH_DISABLE), .str.value = NCSH_DISABLE, .func = &builtins_disable},
+    /*{.flag = BF_EXPORT, .val.length = sizeof(NCSH_EXPORT), .val.value = NCSH_EXPORT, .func = &builtins_export},
+    {.flag = BF_SET, .val.length = sizeof(NCSH_SET), .val.value = NCSH_SET, .func = &builtins_set},
+    {.flag = BF_UNSET, .val.length = sizeof(NCSH_UNSET), .val.value = NCSH_UNSET, .func = &builtins_unset},*/
 };
 
 static constexpr size_t builtins_count = sizeof(builtins) / sizeof(builtins[0]);
@@ -201,32 +200,27 @@ static constexpr size_t builtins_count = sizeof(builtins) / sizeof(builtins[0]);
 #define Z_COMMAND_NOT_FOUND_MESSAGE "ncsh z: command not found, options not supported."
 
 [[nodiscard]]
-static int builtins_z(z_Database* restrict z_db, char** restrict buffer, size_t* restrict buf_lens, Arena* restrict arena, Arena* restrict scratch)
+static int builtins_z(z_Database* restrict z_db, Str* restrict strs, Arena* restrict arena, Arena* restrict scratch)
 {
-    assert(z_db);
-    assert(buffer && *buffer);
-    assert(buf_lens && * buf_lens);
+    assert(z_db); assert(strs && strs->value); assert(arena); assert(scratch);
 
-    if (buf_lens[1] == 0) {
-        z(NULL, 0, NULL, z_db, arena, *scratch);
+    if (strs[1].length == 0) {
+        z(&Str_Empty, NULL, z_db, arena, *scratch);
         return EXIT_SUCCESS;
     }
 
-    assert(buffer && buffer + 1);
-
     // skip first position since we know it is 'z'
-    char** arg = buffer + 1;
-    size_t* arg_lens = buf_lens + 1;
-    if (arg_lens[1] == 0) {
-        assert(arg && *arg);
+    Str* args = strs + 1;
+    if (!args || !args[1].length) {
+        assert(args->value);
 
         // z print
-        if (estrcmp(*arg, *arg_lens, Z_PRINT, sizeof(Z_PRINT))) {
+        if (estrcmp(*args, Str_New_Literal(Z_PRINT))) {
             z_print(z_db);
             return EXIT_SUCCESS;
         }
         // z count
-        if (estrcmp(*arg, *arg_lens, Z_COUNT, sizeof(Z_COUNT))) {
+        if (estrcmp(*args, Str_New_Literal(Z_COUNT))) {
             z_count(z_db);
             return EXIT_SUCCESS;
         }
@@ -238,26 +232,23 @@ static int builtins_z(z_Database* restrict z_db, char** restrict buffer, size_t*
             return EXIT_FAILURE;
         }
 
-        z(*arg, *arg_lens, cwd, z_db, arena, *scratch);
+        z(args, cwd, z_db, arena, *scratch);
         return EXIT_SUCCESS;
     }
 
-    if (arg && arg[1] && !arg[2]) {
-        assert(arg && *arg);
-
+    if (args && args[1].value && !args[2].value) {
         // z add
-        if (estrcmp(*arg, *arg_lens, Z_ADD, sizeof(Z_ADD))) {
-            assert(arg[1] && arg_lens[1]);
-            if (z_add(arg[1], arg_lens[1], z_db, arena) != Z_SUCCESS) {
+        if (estrcmp(*args, Str_New_Literal(Z_ADD))) {
+            if (z_add(&args[1], z_db, arena) != Z_SUCCESS) {
                 return EXIT_FAILURE_CONTINUE;
             }
 
             return EXIT_SUCCESS;
         }
         // z rm/remove
-        else if (estrcmp(*arg, *arg_lens, Z_RM, sizeof(Z_RM)) || estrcmp(*arg, *arg_lens, Z_REMOVE, sizeof(Z_REMOVE))) {
-            assert(arg[1] && arg_lens[1]);
-            if (z_remove(arg[1], arg_lens[1], z_db) != Z_SUCCESS) {
+        else if (estrcmp(*args, Str_New_Literal(Z_RM)) ||
+                estrcmp(*args, Str_New_Literal(Z_REMOVE))) {
+            if (z_remove(&args[1], z_db) != Z_SUCCESS) {
                 return EXIT_FAILURE_CONTINUE;
             }
 
@@ -274,18 +265,18 @@ static int builtins_z(z_Database* restrict z_db, char** restrict buffer, size_t*
 #define HISTORY_COMMAND_NOT_FOUND_MESSAGE "ncsh history: command not found."
 
 [[nodiscard]]
-static int builtins_history(History* restrict history, char** restrict buffer, size_t* restrict buf_lens, Arena* restrict arena,
+static int builtins_history(History* restrict history, Str* restrict strs, Arena* restrict arena,
                      Arena* restrict scratch)
 {
-    if (!buffer || !buffer[1]) {
+    if (!strs || !strs[1].value) {
         return history_command_display(history);
     }
 
-    assert(buffer && *buffer && buffer + 1);
+    assert(strs && *strs->value && strs->value[1]);
 
     // skip first position since we know it is 'history'
-    char** arg = buffer + 1;
-    if (!arg || !*arg) {
+    Str* args = strs + 1;
+    if (!args || !args->value) {
         if (builtins_writeln(vm_output_fd, HISTORY_COMMAND_NOT_FOUND_MESSAGE,
                            sizeof(HISTORY_COMMAND_NOT_FOUND_MESSAGE) - 1) == -1) {
             return EXIT_FAILURE;
@@ -293,35 +284,28 @@ static int builtins_history(History* restrict history, char** restrict buffer, s
         return EXIT_FAILURE_CONTINUE;
     }
 
-    size_t* arg_lens = buf_lens + 1;
-    if (arg && arg_lens[1] == 0) {
-        assert(arg && *arg);
-
-        if (estrcmp(*arg, *arg_lens, NCSH_HISTORY_COUNT, sizeof(NCSH_HISTORY_COUNT))) {
+    if (args && !args[1].length) {
+        if (estrcmp(*args, Str_New_Literal(NCSH_HISTORY_COUNT))) {
             return history_command_count(history);
         }
-        else if (estrcmp(*arg, *arg_lens, NCSH_HISTORY_CLEAN, sizeof(NCSH_HISTORY_CLEAN))) {
+        else if (estrcmp(*args, Str_New_Literal(NCSH_HISTORY_CLEAN))) {
             return history_command_clean(history, arena, scratch);
         }
     }
 
-    if (arg && arg[1] && !arg[2]) {
-        assert(arg && *arg && arg[1] && *arg[1]);
-
+    if (args && args[1].value && !args[2].value) {
         // history add
-        if (estrcmp(*arg, *arg_lens, NCSH_HISTORY_ADD, sizeof(NCSH_HISTORY_ADD))) {
-            assert(arg[1] && arg_lens[1]);
-            if (history_command_add(arg[1], arg_lens[1], history, arena) != Z_SUCCESS) {
+        if (estrcmp(*args, Str_New_Literal(NCSH_HISTORY_ADD))) {
+            if (history_command_add(args[1], history, arena) != Z_SUCCESS) {
                 return EXIT_FAILURE_CONTINUE;
             }
 
             return EXIT_SUCCESS;
         }
         // history rm/remove
-        else if (estrcmp(*arg, *arg_lens, NCSH_HISTORY_RM, sizeof(NCSH_HISTORY_RM)) ||
-                 estrcmp(*arg, *arg_lens, NCSH_HISTORY_REMOVE, sizeof(NCSH_HISTORY_REMOVE))) {
-            assert(arg[1] && arg_lens[1]);
-            if (history_command_remove(arg[1], arg_lens[1], history, arena, scratch) != Z_SUCCESS) {
+        else if (estrcmp(*args, Str_New_Literal(NCSH_HISTORY_RM)) ||
+                 estrcmp(*args, Str_New_Literal(NCSH_HISTORY_REMOVE))) {
+            if (history_command_remove(args[1], history, arena, scratch) != Z_SUCCESS) {
                 return EXIT_FAILURE_CONTINUE;
             }
 
@@ -343,58 +327,52 @@ static int builtins_history(History* restrict history, char** restrict buffer, s
     "alias delete to delete all aliases."
 
 [[nodiscard]]
-static int builtins_alias(char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens, Arena* restrict arena)
+static int builtins_alias(Str* restrict strs, Arena* restrict arena)
 {
-    assert(buffer && *buffer);
+    assert(strs && *strs->value);
 
-    if (!buffer || !buffer[1]) {
+    if (!strs || !strs[1].value) {
         alias_print(vm_output_fd);
         return EXIT_SUCCESS;
     }
 
     // skip first position since we know it is 'alias'
-    char** arg = buffer + 1;
-    size_t* arg_len = buf_lens + 1;
-    if (estrcmp(*arg, *arg_len, NCSH_ALIAS_ADD, sizeof(NCSH_ALIAS_ADD))) {
-        ++arg;
-        ++arg_len;
-        if (!arg || !*arg) {
+    Str* args = strs + 1;
+    if (estrcmp(*args, Str_New_Literal(NCSH_ALIAS_ADD))) {
+        ++args;
+        if (!args || !args->value) {
             if (builtins_writeln(vm_output_fd, ALIAS_ADD_USAGE, sizeof(ALIAS_ADD_USAGE) - 1) == -1) {
                 return EXIT_FAILURE;
             }
             return EXIT_FAILURE_CONTINUE;
         }
-        char* alias = *arg;
-        size_t a_len = *arg_len;
-        ++arg;
-        ++arg_len;
-        if (!arg || !*arg) {
+        Str alias = *args;
+        ++args;
+        if (!args || !args->value) {
             if (builtins_writeln(vm_output_fd, ALIAS_ADD_USAGE, sizeof(ALIAS_ADD_USAGE) - 1) == -1) {
                 return EXIT_FAILURE;
             }
             return EXIT_FAILURE_CONTINUE;
         }
-        char* command = *arg;
-        size_t c_len = *arg_len;
-        alias_add_new(alias, a_len, command, c_len, arena);
+        Str command = *args;
+        alias_add_new(alias, command, arena);
     }
-    else if (estrcmp(*arg, *arg_len, NCSH_ALIAS_RM, sizeof(NCSH_ALIAS_RM)) ||
-             estrcmp(*arg, *arg_len, NCSH_ALIAS_REMOVE, sizeof(NCSH_ALIAS_REMOVE))) {
-        ++arg;
-        ++arg_len;
-        if (!arg || !*arg) {
+    else if (estrcmp(*args, Str_New_Literal(NCSH_ALIAS_RM)) ||
+             estrcmp(*args, Str_New_Literal(NCSH_ALIAS_REMOVE))) {
+        ++args;
+        if (!args || !args->value) {
             if (builtins_writeln(vm_output_fd, ALIAS_REMOVE_USAGE, sizeof(ALIAS_REMOVE_USAGE) - 1) == -1) {
                 return EXIT_FAILURE;
             }
             return EXIT_FAILURE_CONTINUE;
         }
-        alias_remove(*arg, *arg_len);
+        alias_remove(*args);
     }
-    else if (estrcmp(*arg, *arg_len, NCSH_ALIAS_DELETE, sizeof(NCSH_ALIAS_DELETE))) {
+    else if (estrcmp(*args, Str_New_Literal(NCSH_ALIAS_DELETE))) {
         alias_delete();
     }
-    else if (estrcmp(*arg, *arg_len, NCSH_ALIAS_PRINT, sizeof(NCSH_ALIAS_PRINT)) ||
-             estrcmp(*arg, *arg_len, NCSH_ALIAS_PRINT_, sizeof(NCSH_ALIAS_PRINT_))) {
+    else if (estrcmp(*args, Str_New_Literal(NCSH_ALIAS_PRINT)) ||
+             estrcmp(*args, Str_New_Literal(NCSH_ALIAS_PRINT_))) {
         alias_print(vm_output_fd);
     }
     else {
@@ -412,28 +390,26 @@ static int builtins_alias(char** restrict buffer, [[maybe_unused]] size_t* restr
     "alias(es)."
 
 [[nodiscard]]
-static int builtins_unalias(char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_unalias(Str* restrict strs)
 {
-    assert(buffer && *buffer);
+    assert(strs && *strs->value);
 
-    if (!buffer || !buffer[1]) {
+    if (!strs || !strs[1].value) {
         alias_print(vm_output_fd);
         return EXIT_SUCCESS;
     }
 
     // skip first position since we know it is 'unalias'
-    char** arg = buffer + 1;
-    size_t* arg_len = buf_lens + 1;
-    if (estrcmp(*arg, *arg_len, NCSH_UNALIAS_DELETE, sizeof(NCSH_UNALIAS_DELETE)) ||
-        estrcmp(*arg, *arg_len, NCSH_UNALIAS_DELETE_ALIAS, sizeof(NCSH_UNALIAS_DELETE_ALIAS))) {
+    Str* args = strs + 1;
+    if (estrcmp(*args, Str_New_Literal(NCSH_UNALIAS_DELETE)) ||
+        estrcmp(*args, Str_New_Literal(NCSH_UNALIAS_DELETE_ALIAS))) {
         alias_delete();
         return EXIT_SUCCESS;
     }
-    else if (arg) {
-        while (arg) {
-            alias_remove(*arg, *arg_len);
-            ++arg;
-            ++arg_len;
+    else if (args) {
+        while (args) {
+            alias_remove(*args);
+            ++args;
         }
     }
     else {
@@ -447,50 +423,48 @@ static int builtins_unalias(char** restrict buffer, [[maybe_unused]] size_t* res
 }
 
 [[nodiscard]]
-static int builtins_exit([[maybe_unused]] char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_exit([[maybe_unused]] Str* strs)
 {
     return EXIT_SUCCESS_END;
 }
 
 [[nodiscard]]
-static int builtins_echo(char** restrict buffer, size_t* restrict buf_lens)
+static int builtins_echo(Str* restrict strs)
 {
-    assert(buffer && *buffer);
-    char** arg = buffer + 1;
-    size_t* arg_lens = buf_lens + 1;
-    if (!arg || !*arg) {
+    assert(strs && *strs->value);
+    Str* args = strs + 1;
+    if (!args || !args->value) {
         tty_send(&tcaps.newline);
         return EXIT_SUCCESS;
     }
 
     bool echo_add_newline = true;
     // process options for echo
-    while (arg && *arg) {
-        if (estrcmp(*arg, *arg_lens, NCSH_ECHO_NO_NEWLINE, sizeof(NCSH_ECHO_NO_NEWLINE))) {
+    while (args && args->value) {
+        if (estrcmp(*args, Str_New_Literal(NCSH_ECHO_NO_NEWLINE))) {
             echo_add_newline = false;
             break;
         }
-        ++arg;
-        ++arg_lens;
+        ++args;
     }
 
     // send output for echo
-    arg = !echo_add_newline ? arg + 1 : buffer + 1;
-    char* prev = NULL;
-    while (arg && *arg) {
-        prev = *arg;
+    args = !echo_add_newline ? args + 1 : strs + 1;
+    Str* prev = NULL;
+    while (args && args->value) {
+        prev = args;
         if (!prev) {
             break;
         }
-        ++arg;
-        if (!arg || !*arg) {
+        ++args;
+        if (!args || !args->value) {
             break;
         }
 
-        tty_dprint(vm_output_fd, "%s ", prev);
+        tty_dprint(vm_output_fd, "%s ", prev->value);
     }
     if (prev) {
-        tty_dprint(vm_output_fd, "%s", prev);
+        tty_dprint(vm_output_fd, "%s", prev->value);
     }
 
     if (echo_add_newline) {
@@ -557,8 +531,7 @@ static int builtins_echo(char** restrict buffer, size_t* restrict buf_lens)
 
 
 [[nodiscard]]
-static int builtins_help([[maybe_unused]] char** restrict buffer,
-                  [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_help([[maybe_unused]] Str* restrict strs)
 {
     constexpr size_t len = sizeof(NCSH_TITLE) - 1;
     if (builtins_writeln(vm_output_fd, NCSH_TITLE, len) == -1) {
@@ -602,13 +575,13 @@ static int builtins_help([[maybe_unused]] char** restrict buffer,
 #define NCSH_COULD_NOT_CD_MESSAGE "ncsh cd: could not change directory."
 
 [[nodiscard]]
-static int builtins_cd(char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_cd(Str* restrict strs)
 {
-    assert(buffer && *buffer);
+    assert(strs && strs->value);
 
     // skip first position since we know it is 'cd'
-    char* arg = *(buffer + 1);
-    if (!arg) {
+    Str* args = strs + 1;
+    if (!args || !args->value) {
         char* home = getenv("HOME");
         if (!home) {
             if (builtins_writeln(STDERR_FILENO, NCSH_COULD_NOT_CD_MESSAGE, sizeof(NCSH_COULD_NOT_CD_MESSAGE) - 1) == -1)
@@ -621,7 +594,7 @@ static int builtins_cd(char** restrict buffer, [[maybe_unused]] size_t* restrict
         return EXIT_SUCCESS;
     }
 
-    if (chdir(arg)) {
+    if (chdir(args->value)) {
         if (builtins_writeln(STDERR_FILENO, NCSH_COULD_NOT_CD_MESSAGE, sizeof(NCSH_COULD_NOT_CD_MESSAGE) - 1) == -1)
             return EXIT_FAILURE;
     }
@@ -630,7 +603,7 @@ static int builtins_cd(char** restrict buffer, [[maybe_unused]] size_t* restrict
 }
 
 [[nodiscard]]
-static int builtins_pwd([[maybe_unused]] char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_pwd([[maybe_unused]] Str* restrict strs)
 {
     char path[PATH_MAX];
     if (!getcwd(path, sizeof(path))) {
@@ -646,10 +619,10 @@ static int builtins_pwd([[maybe_unused]] char** restrict buffer, [[maybe_unused]
 #define KILL_COULDNT_PARSE_PID_MESSAGE "ncsh kill: could not parse process ID (PID) from arguments."
 
 [[nodiscard]]
-static int builtins_kill(char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_kill(Str* restrict strs)
 {
-    assert(buffer && *buffer && buffer + 1);
-    if (!buffer) {
+    assert(strs);
+    if (!strs || !strs->value || !strs->value[1]) {
         if (builtins_writeln(vm_output_fd, KILL_NOTHING_TO_KILL_MESSAGE, sizeof(KILL_NOTHING_TO_KILL_MESSAGE) - 1) ==
             -1) {
             return EXIT_FAILURE;
@@ -659,17 +632,9 @@ static int builtins_kill(char** restrict buffer, [[maybe_unused]] size_t* restri
     }
 
     // skip first position since we know it is 'kill'
-    char* arg = *(buffer + 1);
-    if (!arg || !*arg) {
-        if (builtins_writeln(vm_output_fd, KILL_NOTHING_TO_KILL_MESSAGE, sizeof(KILL_NOTHING_TO_KILL_MESSAGE) - 1) ==
-            -1) {
-            return EXIT_FAILURE;
-        }
+    Str* args = strs + 1;
 
-        return EXIT_SUCCESS;
-    }
-
-    pid_t pid = atoi(arg);
+    pid_t pid = atoi(args->value);
     if (!pid) {
         if (builtins_writeln(vm_output_fd, KILL_COULDNT_PARSE_PID_MESSAGE, sizeof(KILL_COULDNT_PARSE_PID_MESSAGE) - 1) ==
             -1) {
@@ -687,20 +652,20 @@ static int builtins_kill(char** restrict buffer, [[maybe_unused]] size_t* restri
 }
 
 [[nodiscard]]
-static int builtins_version([[maybe_unused]] char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_version([[maybe_unused]] Str* restrict strs)
 {
     builtins_writeln(vm_output_fd, NCSH_TITLE, sizeof(NCSH_TITLE) - 1);
     return EXIT_SUCCESS;
 }
 
 [[nodiscard]]
-static int builtins_true([[maybe_unused]] char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_true([[maybe_unused]] Str* restrict strs)
 {
     return EXIT_SUCCESS;
 }
 
 [[nodiscard]]
-static int builtins_false([[maybe_unused]] char** restrict buffer, [[maybe_unused]] size_t* restrict buf_lens)
+static int builtins_false([[maybe_unused]] Str* restrict strs)
 {
     return EXIT_FAILURE;
 }
@@ -708,7 +673,7 @@ static int builtins_false([[maybe_unused]] char** restrict buffer, [[maybe_unuse
 void builtins_print()
 {
     for (size_t i = 0; i < builtins_count; ++i) {
-        tty_println("%s", builtins[i].value);
+        tty_println("%s", builtins[i].str.value);
     }
 }
 
@@ -716,32 +681,32 @@ void builtins_print_enabled()
 {
     if (!builtins_disabled_state) {
         for (size_t i = 0; i < builtins_count; ++i) {
-            tty_println("%s: enabled", builtins[i].value);
+            tty_println("%s: enabled", builtins[i].str.value);
         }
     }
     else {
         for (size_t i = 0; i < builtins_count; ++i) {
             if ((builtins_disabled_state & builtins[i].flag)) {
-                tty_println("%s: disabled", builtins[i].value);
+                tty_println("%s: disabled", builtins[i].str.value);
             }
             else {
-                tty_println("%s: enabled", builtins[i].value);
+                tty_println("%s: enabled", builtins[i].str.value);
             }
         }
     }
 }
 
-static int builtins_disable__(char* restrict buffer, size_t len)
+static int builtins_disable__(Str* restrict str)
 {
     for (size_t i = 0; i < builtins_count; ++i) {
-        if (estrcmp(buffer, len, builtins[i].value, builtins[i].length)) {
+        if (estrcmp(*str, builtins[i].str)) {
             if (builtins_disabled_state & builtins[i].flag) {
-                tty_println("ncsh disable: the builtin '%s' was already disable", builtins[i].value);
+                tty_println("ncsh disable: the builtin '%s' was already disable", builtins[i].str.value);
                 return EXIT_SUCCESS;
             }
             if (builtins_disabled_state == 0 || builtins_disabled_state | builtins[i].flag) {
                 builtins_disabled_state |= builtins[i].flag;
-                tty_println("ncsh disable: disabled builtin %s.", builtins[i].value);
+                tty_println("ncsh disable: disabled builtin %s.", builtins[i].str.value);
                 return EXIT_SUCCESS;
             }
         }
@@ -752,19 +717,18 @@ static int builtins_disable__(char* restrict buffer, size_t len)
 #define DISABLE_BUILTIN_NOT_FOUND "ncsh disable: command not found, could not disable."
 #define DISABLE_NO_COMMAND_ARG "ncsh enable: no command passed in to disable."
 [[nodiscard]]
-static int builtins_disable(char** restrict buffer, size_t* restrict buf_lens)
+static int builtins_disable(Str* restrict strs)
 {
-    assert(buffer && *buffer);
+    assert(strs && strs->value);
 
     // skip first position since we know it is 'enable' or 'disable'
-    char** arg = buffer + 1;
-    if (!arg || !*arg) {
+    Str* args = strs + 1;
+    if (!args || !args->value) {
         builtins_print();
         return EXIT_SUCCESS;
     }
-    size_t* arg_lens = buf_lens + 1;
 
-    if (!builtins_disable__(*arg, *arg_lens))
+    if (!builtins_disable__(args))
         return EXIT_SUCCESS;
 
     builtins_writeln(vm_output_fd, DISABLE_BUILTIN_NOT_FOUND, sizeof(DISABLE_BUILTIN_NOT_FOUND) - 1);
@@ -774,38 +738,37 @@ static int builtins_disable(char** restrict buffer, size_t* restrict buf_lens)
 #define ENABLE_OPTION_NOT_SUPPORTED_MESSAGE "ncsh enable: command not found, options entered not supported."
 
 [[nodiscard]]
-static int builtins_enable(char** restrict buffer, size_t* restrict buf_lens)
+static int builtins_enable(Str* restrict strs)
 {
-    assert(buffer && *buffer);
+    assert(strs && strs->value);
 
     // skip first position since we know it is 'enable'
-    char** arg = buffer + 1;
-    if (!arg || !*arg) {
+    Str* args = strs + 1;
+    if (!args || !args->value) {
         builtins_print();
         return EXIT_SUCCESS;
     }
-    size_t* arg_lens = buf_lens + 1;
 
-    if (*arg_lens == 3) {
-        if (estrcmp(*arg, *arg_lens, "-a", sizeof("-a"))) {
+    if (args->length == 3) {
+        if (estrcmp(*args, Str_New_Literal("-a"))) {
             builtins_print_enabled();
             return EXIT_SUCCESS;
         }
-        else if (estrcmp(*arg, *arg_lens, "-n", sizeof("-n"))) {
-            ++arg; ++arg_lens;
-            return builtins_disable__(*arg, *arg_lens);
+        else if (estrcmp(*args, Str_New_Literal("-n"))) {
+            ++args;
+            return builtins_disable__(args);
         }
     }
 
     for (size_t i = 0; i < builtins_count; ++i) {
-        if (estrcmp(*arg, *arg_lens, builtins[i].value, builtins[i].length)) {
+        if (estrcmp(*args, builtins[i].str)) {
             if (builtins_disabled_state == 0 || !(builtins_disabled_state & builtins[i].flag)) {
-                tty_println("ncsh enable: the builtin '%s' is already enabled", builtins[i].value);
+                tty_println("ncsh enable: the builtin '%s' is already enabled", builtins[i].str.value);
                 return EXIT_SUCCESS;
             }
             if (builtins_disabled_state & builtins[i].flag) {
                 builtins_disabled_state ^= builtins[i].flag;
-                tty_println("ncsh enable: enabled builtin %s.", builtins[i].value);
+                tty_println("ncsh enable: enabled builtin %s.", builtins[i].str.value);
                 return EXIT_SUCCESS;
             }
         }
@@ -907,13 +870,13 @@ static int builtins_enable(char** restrict buffer, size_t* restrict buf_lens)
 
 #define UNSET_NOTHING_TO_UNSET_MESSAGE "ncsh unset: nothing to unset, please pass in a value to unset."
 [[nodiscard]]
-static int builtins_unset(char** restrict buffer, size_t* restrict buf_lens, Env* restrict env)
+static int builtins_unset(Str* restrict strs, Env* restrict env)
 {
-    assert(buffer); assert(buf_lens); assert(env);
+    assert(strs); assert(strs->value); assert(env);
 
     // skip first position since we know it is 'unset'
-    char** args = buffer + 1;
-    if (!args || !*args) {
+    Str* args = strs + 1;
+    if (!args || !args->value) {
         if (builtins_writeln(vm_output_fd,
                            UNSET_NOTHING_TO_UNSET_MESSAGE,
                            sizeof(UNSET_NOTHING_TO_UNSET_MESSAGE) - 1) == -1) {
@@ -923,7 +886,7 @@ static int builtins_unset(char** restrict buffer, size_t* restrict buf_lens, Env
         return EXIT_SUCCESS;
     }
 
-    Str* val = env_add_or_get(env, Str_New(*args, *(buf_lens + 1)));
+    Str* val = env_add_or_get(env, *args);
     if (!val || !val->value) {
         return EXIT_SUCCESS;
     }
@@ -940,42 +903,42 @@ static int builtins_unset(char** restrict buffer, size_t* restrict buf_lens, Env
 bool builtins_check_and_run(Vm_Data* restrict vm, Shell* restrict shell, Arena* restrict scratch)
 {
     if (shell) {
-        if (estrcmp(vm->buffer[0], vm->buffer_lens[0], Z, sizeof(Z))) {
-            vm->status = builtins_z(&shell->z_db, vm->buffer, vm->buffer_lens, &shell->arena, scratch);
+        if (estrcmp(vm->strs[0], Str_New_Literal(Z))) {
+            vm->status = builtins_z(&shell->z_db, vm->strs, &shell->arena, scratch);
             return true;
         }
 
-        if (estrcmp(vm->buffer[0], vm->buffer_lens[0], NCSH_HISTORY, sizeof(NCSH_HISTORY))) {
+        if (estrcmp(vm->strs[0], Str_New_Literal(NCSH_HISTORY))) {
             if (builtins_disabled_state & BF_HISTORY) {
                 return false;
             }
-            vm->status = builtins_history(&shell->input.history, vm->buffer, vm->buffer_lens, &shell->arena, scratch);
+            vm->status = builtins_history(&shell->input.history, vm->strs, &shell->arena, scratch);
             return true;
         }
 
-        if (estrcmp(vm->buffer[0], vm->buffer_lens[0], NCSH_ALIAS, sizeof(NCSH_ALIAS))) {
+        if (estrcmp(vm->strs[0], Str_New_Literal(NCSH_ALIAS))) {
             if (builtins_disabled_state & BF_ALIAS) {
                 return false;
             }
-            vm->status = builtins_alias(vm->buffer, vm->buffer_lens, &shell->arena);
+            vm->status = builtins_alias(vm->strs, &shell->arena);
             return true;
         }
 
-        if (estrcmp(vm->buffer[0], vm->buffer_lens[0], NCSH_UNSET, sizeof(NCSH_UNSET))) {
+        if (estrcmp(vm->strs[0], Str_New_Literal(NCSH_UNSET))) {
             if (builtins_disabled_state & BF_UNSET) {
                 return false;
             }
-            vm->status = builtins_unset(vm->buffer, vm->buffer_lens, shell->env);
+            vm->status = builtins_unset(vm->strs, shell->env);
             return true;
         }
     }
 
     for (size_t i = 0; i < builtins_count; ++i) {
-        if (estrcmp(vm->buffer[0], vm->buffer_lens[0], builtins[i].value, builtins[i].length)) {
+        if (estrcmp(vm->strs[0], builtins[i].str)) {
             if (builtins_disabled_state & builtins[i].flag) {
                 return false;
             }
-            vm->status = (*builtins[i].func)(vm->buffer, vm->buffer_lens);
+            vm->status = (*builtins[i].func)(vm->strs);
             return true;
         }
     }

--- a/src/interpreter/expansions.c
+++ b/src/interpreter/expansions.c
@@ -27,28 +27,28 @@ void expansion_home(Shell* shell, Lexemes* restrict lexemes, size_t pos, Arena* 
         return;
     }
 
-    if (lexemes->lens[pos] == 2) {
-        lexemes->lens[pos] = home->length;
-        lexemes->vals[pos] = arena_malloc(scratch, lexemes->lens[pos], char);
-        memcpy(lexemes->vals[pos], home->value, lexemes->lens[pos] - 1);
+    if (lexemes->strs[pos].length == 2) {
+        lexemes->strs[pos].length = home->length;
+        lexemes->strs[pos].value = arena_malloc(scratch, lexemes->strs[pos].length, char);
+        memcpy(lexemes->strs[pos].value, home->value, lexemes->strs[pos].length - 1);
         lexemes->ops[pos] = OP_CONSTANT;
-        debugf("lexemes->vals[pos] set to %s\n", lexemes->vals[pos]);
+        debugf("lexemes->strs[pos].value set to %s\n", lexemes->strs[pos].value);
         return;
     }
 
-    assert(lexemes->vals[pos]);
+    assert(lexemes->strs[pos].value);
     // only do home expansion when there is a value and home is in first position.
-    if (!lexemes->vals[pos] || lexemes->vals[pos][0] != '~')
+    if (!lexemes->strs[pos].value || lexemes->strs[pos].value[0] != '~')
         return;
 
-    size_t len = lexemes->lens[pos] + home->length - 2; // subtract 1, both account for null termination
+    size_t len = lexemes->strs[pos].length + home->length - 2; // subtract 1, both account for null termination
     char* new_value = arena_malloc(scratch, len, char);
     memcpy(new_value, home->value, home->length - 1);
-    memcpy(new_value + home->length - 1, lexemes->vals[pos] + 1, lexemes->lens[pos] - 1);
-    debugf("performing home expansion on %s to %s\n", lexemes->vals[pos], new_value);
-    lexemes->vals[pos] = new_value;
+    memcpy(new_value + home->length - 1, lexemes->strs[pos].value + 1, lexemes->strs[pos].length - 1);
+    debugf("performing home expansion on %s to %s\n", lexemes->strs[pos].value, new_value);
+    lexemes->strs[pos].value = new_value;
     lexemes->ops[pos] = OP_CONSTANT;
-    lexemes->lens[pos] = len;
+    lexemes->strs[pos].length = len;
 }
 
 void expansion_glob(char* restrict in, Commands* restrict cmds, Arena* restrict scratch)
@@ -72,9 +72,9 @@ void expansion_glob(char* restrict in, Commands* restrict cmds, Arena* restrict 
 
         glob_len = strlen(glob_buf.gl_pathv[i]) + 1;
         debugf("cmds->pos: %zu\n", cmds->pos);
-        cmds->vals[cmds->pos] = arena_malloc(scratch, glob_len, char);
-        memcpy(cmds->vals[cmds->pos], glob_buf.gl_pathv[i], glob_len);
-        cmds->lens[cmds->pos] = glob_len;
+        cmds->strs[cmds->pos].value = arena_malloc(scratch, glob_len, char);
+        memcpy(cmds->strs[cmds->pos].value, glob_buf.gl_pathv[i], glob_len);
+        cmds->strs[cmds->pos].length = glob_len;
         cmds->ops[cmds->pos] = OP_CONSTANT;
         ++cmds->pos;
     }
@@ -90,43 +90,47 @@ void expansion_assignment(Lexemes* lexeme, size_t pos, Shell* restrict shell)
     // the key is the previous value, which is tagged with OP_VARIABLE.
     // when VM comes in contact with OP_VARIABLE, it looks up value in env.
     size_t assignment_pos;
-    for (assignment_pos = 0; assignment_pos < lexeme->lens[pos]; ++assignment_pos) {
-        if (lexeme->vals[pos][assignment_pos] == '=')
+    for (assignment_pos = 0; assignment_pos < lexeme->strs[pos].length; ++assignment_pos) {
+        if (lexeme->strs[pos].value[assignment_pos] == '=')
             break;
     }
 
     Str key = {.length = assignment_pos + 1};
     key.value = arena_malloc(&shell->arena, key.length, char);
-    memcpy(key.value, lexeme->vals[pos], assignment_pos);
+    memcpy(key.value, lexeme->strs[pos].value, assignment_pos);
 
-    Str val = {.length = lexeme->lens[pos] - assignment_pos - 1};
+    Str val = {.length = lexeme->strs[pos].length - assignment_pos - 1};
     val.value = arena_malloc(&shell->arena, val.length, char);
-    memcpy(val.value, lexeme->vals[pos] + key.length, val.length);
+    memcpy(val.value, lexeme->strs[pos].value + key.length, val.length);
     debugf("setting key %s with val %s\n", key.value, val.value);
 
     *env_add_or_get(shell->env, key) = val;
 }
 
-void expansion_variable(char* restrict in, size_t len, Commands* restrict cmds, /*Statements* stmts,*/ Shell* restrict shell, Arena* restrict scratch)
+void expansion_variable(Str* restrict in, Commands* restrict cmds, /*Statements* stmts,*/ Shell* restrict shell, Arena* restrict scratch)
 {
-    assert(in); assert(cmds); assert(shell); assert(scratch);
-    if (!in || len < 2) {
+    assert(in); assert(in->value); assert(cmds); assert(shell); assert(scratch);
+    if (!in || in->length < 2) {
         return;
     }
 
-    char* key = in[0] == '$' ? in + 1 : in; // skip first value if $
-    size_t key_len = in[0] == '$' ? len - 1 : len;
-    debugf("key %s, key_len %zu\n", key, key_len);
-    Str* val = env_add_or_get(shell->env, Str_New(key, key_len));
+    Str key;
+    if (in->value[0] == '$')
+        key = (Str){.value = in->value + 1, .length = in->length - 1};
+    else
+        key = (Str){.value = in->value, .length = in->length};
+
+    debugf("key %s, key_len %zu\n", key.value, key.length);
+    Str* val = env_add_or_get(shell->env, key);
     if (!val || !val->value) {
         return;
     }
 
     debugf("var %s %zu\n", val->value, val->length);
 
-    cmds->vals[cmds->pos] = arena_malloc(scratch, val->length, char);
-    memcpy(cmds->vals[cmds->pos], val->value, val->length - 1);
-    cmds->lens[cmds->pos] = val->length;
+    cmds->strs[cmds->pos].value = arena_malloc(scratch, val->length, char);
+    memcpy(cmds->strs[cmds->pos].value, val->value, val->length - 1);
+    cmds->strs[cmds->pos].length = val->length;
     cmds->ops[cmds->pos] = OP_CONSTANT;
     ++cmds->pos;
 
@@ -160,19 +164,19 @@ void expansion_variable(char* restrict in, size_t len, Commands* restrict cmds, 
 void expansion_alias(Lexemes* restrict lexemes, size_t n, Arena* restrict scratch)
 {
     // TODO: alias expansion. Aliases with " " are not expanded into multiple commands.
-    Str alias = alias_check(lexemes->vals[n], lexemes->lens[n]);
+    Str alias = alias_check(lexemes->strs[n]);
     if (!alias.length) {
         return;
     }
 
     char* space = strchr(alias.value, ' ');
     if (!space) {
-        if (alias.length > lexemes->lens[n]) {
-            lexemes->vals[n] = arena_realloc(scratch, alias.length, char, lexemes->vals[n], lexemes->lens[n]);
+        if (alias.length > lexemes->strs[n].length) {
+            lexemes->strs[n].value = arena_realloc(scratch, alias.length, char, lexemes->strs[n].value, lexemes->strs[n].length);
         }
 
-        memcpy(lexemes->vals[n], alias.value, alias.length);
-        lexemes->lens[n] = alias.length;
+        memcpy(lexemes->strs[n].value, alias.value, alias.length);
+        lexemes->strs[n].length = alias.length;
         return;
     }
 

--- a/src/interpreter/expansions.h
+++ b/src/interpreter/expansions.h
@@ -12,6 +12,6 @@ void expansion_glob(char* restrict in, Commands* restrict cmds, Arena* restrict 
 
 void expansion_assignment(Lexemes* lexeme, size_t pos, Shell* restrict shell);
 
-void expansion_variable(char* restrict in, size_t len, Commands* restrict cmds, /*Statements* stmts,*/ Shell* shell, Arena* scratch);
+void expansion_variable(Str* restrict in, Commands* restrict cmds, /*Statements* stmts,*/ Shell* shell, Arena* scratch);
 
 void expansion_alias(Lexemes* restrict lexemes, size_t n, Arena* restrict scratch);

--- a/src/interpreter/lexemes.c
+++ b/src/interpreter/lexemes.c
@@ -10,8 +10,7 @@ void lexemes_init(Lexemes* restrict lexemes, Arena* restrict scratch)
     assert(lexemes);
 
     lexemes->ops = arena_malloc(scratch, LEXER_TOKENS_LIMIT, uint8_t);
-    lexemes->lens = arena_malloc(scratch, LEXER_TOKENS_LIMIT, size_t);
-    lexemes->vals = arena_malloc(scratch, LEXER_TOKENS_LIMIT, char*);
+    lexemes->strs = arena_malloc(scratch, LEXER_TOKENS_LIMIT, Str);
 }
 
 void lexemes_init_n(Lexemes* restrict lexemes, size_t n, Arena* restrict scratch)
@@ -22,11 +21,8 @@ void lexemes_init_n(Lexemes* restrict lexemes, size_t n, Arena* restrict scratch
     [[maybe_unused]] uint8_t* ops = lexemes->ops + n;
     ops = arena_malloc(scratch, LEXER_TOKENS_LIMIT, uint8_t);
 
-    [[maybe_unused]] size_t* lens = lexemes->lens + n;
-    lens = arena_malloc(scratch, LEXER_TOKENS_LIMIT, size_t);
-
-    [[maybe_unused]] char** vals = lexemes->vals + n;
-    vals = arena_malloc(scratch, LEXER_TOKENS_LIMIT, char*);
+    [[maybe_unused]] Str* strs = lexemes->strs + n;
+    strs = arena_malloc(scratch, LEXER_TOKENS_LIMIT, Str);
 }
 
 /*Lexemes* lexemes_alloc(Arena* restrict scratch)

--- a/src/interpreter/lexemes.c
+++ b/src/interpreter/lexemes.c
@@ -24,13 +24,3 @@ void lexemes_init_n(Lexemes* restrict lexemes, size_t n, Arena* restrict scratch
     [[maybe_unused]] Str* strs = lexemes->strs + n;
     strs = arena_malloc(scratch, LEXER_TOKENS_LIMIT, Str);
 }
-
-/*Lexemes* lexemes_alloc(Arena* restrict scratch)
-{
-    Lexemes* lexemes = arena_malloc(scratch, 1, Lexemes);
-    lexemes->count = 0;
-    lexemes->ops = arena_malloc(scratch, LEXER_TOKENS_LIMIT, uint8_t);
-    lexemes->lens = arena_malloc(scratch, LEXER_TOKENS_LIMIT, size_t);
-    lexemes->vals = arena_malloc(scratch, LEXER_TOKENS_LIMIT, char*);
-    return lexemes;
-}*/

--- a/src/interpreter/lexemes.h
+++ b/src/interpreter/lexemes.h
@@ -6,20 +6,14 @@
 #include <unistd.h>
 
 #include "../arena.h"
+#include "../eskilib/str.h"
 
 #define LEXER_TOKENS_LIMIT 128
 
 typedef struct {
-    uint8_t op;
-    size_t len;
-    char* val;
-} Lexeme;
-
-typedef struct {
     size_t count;
     uint8_t* ops;
-    size_t* lens;
-    char** vals;
+    Str* strs;
 } Lexemes;
 
 void lexemes_init(Lexemes* restrict lexemes, Arena* restrict scratch);

--- a/src/interpreter/lexer.c
+++ b/src/interpreter/lexer.c
@@ -410,9 +410,9 @@ void lexer_lex(char* restrict line, size_t length, Lexemes* lexemes, Arena* rest
         debugf("Current lexer state: %d\n", lex_state);
 
         lexemes->ops[n] = lexer_op_process();
-        lexemes->lens[n] = lex_buf_pos + 1;
-        lexemes->vals[n] = arena_malloc(scratch, lexemes->lens[n], char);
-        memcpy(lexemes->vals[n], lex_buf, lex_buf_pos);
+        lexemes->strs[n].length = lex_buf_pos + 1;
+        lexemes->strs[n].value = arena_malloc(scratch, lexemes->strs[n].length, char);
+        memcpy(lexemes->strs[n].value, lex_buf, lex_buf_pos);
         ++n;
 
         lex_buf[0] = '\0';

--- a/src/interpreter/lexer.c
+++ b/src/interpreter/lexer.c
@@ -412,8 +412,7 @@ void lexer_lex(char* restrict line, size_t length, Lexemes* lexemes, Arena* rest
         lexemes->ops[n] = lexer_op_process();
         lexemes->strs[n].length = lex_buf_pos + 1;
         lexemes->strs[n].value = arena_malloc(scratch, lexemes->strs[n].length, char);
-        memcpy(lexemes->strs[n].value, lex_buf, lex_buf_pos);
-        ++n;
+        memcpy(lexemes->strs[n++].value, lex_buf, lex_buf_pos);
 
         lex_buf[0] = '\0';
         lex_buf_pos = 0;

--- a/src/interpreter/parser.c
+++ b/src/interpreter/parser.c
@@ -377,7 +377,6 @@ int parser_parse(Lexemes* restrict lexemes, Statements* stmts, Shell* restrict s
         }
 
         commands->strs[commands->pos] = lexemes->strs[i];
-        // commands->strs[commands->pos] = *estrdup(&lexemes->strs[i], scratch);
         commands->ops[commands->pos] = lexemes->ops[i];
         ++commands->pos;
     }

--- a/src/interpreter/parser.c
+++ b/src/interpreter/parser.c
@@ -83,7 +83,6 @@ int parser_commands_process(Shell* shell, Lexemes* restrict lexemes, size_t* res
         case OP_EQUALS:
         case OP_LESS_THAN:
         case OP_GREATER_THAN: {
-            commands->current_op = lexemes->ops[*n];
             commands->prev_op = lexemes->ops[*n];
             break;
         }
@@ -96,7 +95,6 @@ int parser_commands_process(Shell* shell, Lexemes* restrict lexemes, size_t* res
             continue;
         case OP_PIPE:
             ++stmts->pipes_count;
-            commands[commands->pos - 1].current_op = OP_PIPE;
             commands = command_next(commands, scratch);
             commands->prev_op = OP_PIPE;
             continue;
@@ -108,7 +106,6 @@ int parser_commands_process(Shell* shell, Lexemes* restrict lexemes, size_t* res
             continue;
         case OP_AND:
         case OP_OR: {
-            commands->current_op = lexemes->ops[*n];
             commands = command_next(commands, scratch);
             commands->prev_op = lexemes->ops[*n];
             ++*n;
@@ -320,7 +317,6 @@ int parser_parse(Lexemes* restrict lexemes, Statements* stmts, Shell* restrict s
         case OP_EQUALS:
         case OP_LESS_THAN:
         case OP_GREATER_THAN: {
-            commands->current_op = lexemes->ops[i];
             commands->prev_op = lexemes->ops[i];
             break;
         }
@@ -341,7 +337,6 @@ int parser_parse(Lexemes* restrict lexemes, Statements* stmts, Shell* restrict s
         }
         case OP_PIPE: {
             ++stmts->pipes_count;
-            commands[commands->pos - 1].current_op = OP_PIPE;
             commands = command_next(commands, scratch);
             commands->prev_op = OP_PIPE;
             continue;
@@ -362,7 +357,6 @@ int parser_parse(Lexemes* restrict lexemes, Statements* stmts, Shell* restrict s
         }
         case OP_AND:
         case OP_OR: {
-            commands->current_op = lexemes->ops[i];
             commands = command_next(commands, scratch);
             commands->prev_op = lexemes->ops[i];
             continue;
@@ -383,6 +377,7 @@ int parser_parse(Lexemes* restrict lexemes, Statements* stmts, Shell* restrict s
         }
 
         commands->strs[commands->pos] = lexemes->strs[i];
+        // commands->strs[commands->pos] = *estrdup(&lexemes->strs[i], scratch);
         commands->ops[commands->pos] = lexemes->ops[i];
         ++commands->pos;
     }

--- a/src/interpreter/statements.c
+++ b/src/interpreter/statements.c
@@ -53,7 +53,7 @@ Commands* command_next(Commands* restrict cmds, Arena* restrict scratch)
     }
 
     cmds->next = commands_alloc(scratch);
-    cmds->strs[cmds->pos].value = NULL;
+    // cmds->strs[cmds->pos].value = NULL;
     cmds->pos = 0;
 
     cmds = cmds->next;

--- a/src/interpreter/statements.c
+++ b/src/interpreter/statements.c
@@ -4,16 +4,16 @@
 #include "../arena.h"
 #include "statements.h"
 
-#define DEFAULT_N 10
-#define MAX_N 40
+#define STMT_DEFAULT_N 10
+#define STMT_MAX_N 40
 
 Commands* commands_alloc(Arena* restrict scratch)
 {
     Commands* c = arena_malloc(scratch, 1, Commands);
     c->count = 0;
-    c->cap = DEFAULT_N;
-    c->strs = arena_malloc(scratch, DEFAULT_N, Str);
-    c->ops = arena_malloc(scratch, DEFAULT_N, enum Ops);
+    c->cap = STMT_DEFAULT_N;
+    c->strs = arena_malloc(scratch, STMT_DEFAULT_N, Str);
+    c->ops = arena_malloc(scratch, STMT_DEFAULT_N, enum Ops);
     c->next = NULL;
     c->prev_op = OP_NONE;
     return c;
@@ -72,18 +72,12 @@ Commands* command_statement_next(Statements* restrict stmts, Commands* cmds, enu
 void statements_init(Statements* restrict stmts, Arena* restrict scratch)
 {
     assert(stmts);
-    stmts->statements = arena_malloc(scratch, DEFAULT_N, Statement);
+    stmts->statements = arena_malloc(scratch, STMT_DEFAULT_N, Statement);
     stmts->type = ST_NORMAL;
     stmts->statements->count = 0;
     stmts->statements->type = LT_NORMAL;
     stmts->statements->commands = commands_alloc(scratch);
 }
-
-// TODO: implement?
-/*void statements_realloc(Statements* restrict statements, Arena* restrict scratch)
-{
-
-}*/
 
 void statement_next(Statements* restrict stmts, enum Logic_Type type, Arena* restrict scratch)
 {
@@ -91,6 +85,6 @@ void statement_next(Statements* restrict stmts, enum Logic_Type type, Arena* res
     ++stmts->statements[stmts->pos].count;
     ++stmts->pos;
     ++stmts->count;
-    stmts->cap = DEFAULT_N;
+    stmts->cap = STMT_DEFAULT_N;
     stmts->statements[stmts->pos].commands = commands_alloc(scratch);
 }

--- a/src/interpreter/statements.c
+++ b/src/interpreter/statements.c
@@ -12,8 +12,7 @@ Commands* commands_alloc(Arena* restrict scratch)
     Commands* c = arena_malloc(scratch, 1, Commands);
     c->count = 0;
     c->cap = DEFAULT_N;
-    c->vals = arena_malloc(scratch, DEFAULT_N, char*);
-    c->lens = arena_malloc(scratch, DEFAULT_N, size_t);
+    c->strs = arena_malloc(scratch, DEFAULT_N, Str);
     c->ops = arena_malloc(scratch, DEFAULT_N, enum Ops);
     c->next = NULL;
     c->current_op = OP_NONE;
@@ -26,10 +25,8 @@ void command_realloc(Commands* restrict cmds, Arena* restrict scratch)
     size_t c = cmds->cap;
     size_t new_cap = c *= 2;
     cmds->cap = new_cap;
-    cmds->vals =
-        arena_realloc(scratch, new_cap, char*, cmds->vals, c);
-    cmds->lens =
-        arena_realloc(scratch, new_cap, size_t, cmds->lens, c);
+    cmds->strs =
+        arena_realloc(scratch, new_cap, Str, cmds->strs, c);
     cmds->ops =
         arena_realloc(scratch, new_cap, enum Ops, cmds->ops, c);
 }
@@ -39,10 +36,8 @@ void commands_realloc(Statements* restrict stmts, Arena* restrict scratch)
     size_t c = stmts->statements[stmts->count].commands->cap;
     size_t new_cap = c *= 2;
     stmts->statements[stmts->count].commands->cap = new_cap;
-    stmts->statements[stmts->count].commands->vals =
-        arena_realloc(scratch, new_cap, char*, stmts->statements[stmts->count].commands->vals, c);
-    stmts->statements[stmts->count].commands->lens =
-        arena_realloc(scratch, new_cap, size_t, stmts->statements[stmts->count].commands->lens, c);
+    stmts->statements[stmts->count].commands->strs =
+        arena_realloc(scratch, new_cap, Str, stmts->statements[stmts->count].commands->strs, c);
     stmts->statements[stmts->count].commands->ops =
         arena_realloc(scratch, new_cap, enum Ops, stmts->statements[stmts->count].commands->ops, c);
 }
@@ -51,14 +46,14 @@ Commands* command_next(Commands* restrict cmds, Arena* restrict scratch)
 {
     if (!cmds->pos) {
         cmds->count = 1;
-        cmds->vals[1] = NULL;
+        cmds->strs[1].value = NULL;
     }
     else {
         cmds->count = cmds->pos;
     }
 
     cmds->next = commands_alloc(scratch);
-    cmds->vals[cmds->pos] = NULL;
+    cmds->strs[cmds->pos].value = NULL;
     cmds->pos = 0;
 
     cmds = cmds->next;

--- a/src/interpreter/statements.c
+++ b/src/interpreter/statements.c
@@ -15,7 +15,6 @@ Commands* commands_alloc(Arena* restrict scratch)
     c->strs = arena_malloc(scratch, DEFAULT_N, Str);
     c->ops = arena_malloc(scratch, DEFAULT_N, enum Ops);
     c->next = NULL;
-    c->current_op = OP_NONE;
     c->prev_op = OP_NONE;
     return c;
 }
@@ -53,7 +52,7 @@ Commands* command_next(Commands* restrict cmds, Arena* restrict scratch)
     }
 
     cmds->next = commands_alloc(scratch);
-    // cmds->strs[cmds->pos].value = NULL;
+    cmds->strs[cmds->pos].value = NULL;
     cmds->pos = 0;
 
     cmds = cmds->next;

--- a/src/interpreter/statements.h
+++ b/src/interpreter/statements.h
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include "../arena.h"
+#include "../eskilib/str.h"
 #include "ops.h"
 
 enum Redirect_Type : uint8_t {
@@ -26,8 +27,7 @@ typedef struct Commands_ {
     enum Ops prev_op;
 
     enum Ops* ops;
-    size_t* lens;
-    char** vals;
+    Str* strs;
 
     struct Commands_* next;
 } Commands;

--- a/src/interpreter/statements.h
+++ b/src/interpreter/statements.h
@@ -23,7 +23,6 @@ typedef struct Commands_ {
     size_t pos;
     size_t count;
     size_t cap;
-    enum Ops current_op;
     enum Ops prev_op;
 
     enum Ops* ops;

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -577,7 +577,7 @@ int vm_run(Statements* restrict stmts, Shell* restrict shell, Arena* restrict sc
                     pipe_connect(vm.command_position, stmts->pipes_count, &vm.pipes_io);
 
                 char** buffers = estrtoarr(vm.strs, vm.strs_n, scratch);
-                vm.exec_result = execvp(buffers[0], buffers);
+                vm.exec_result = execvp(*buffers, buffers);
                 if (vm.exec_result == EXECVP_FAILED) {
                     vm.end = true;
                     tty_perror("ncsh: Could not run command");

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -492,7 +492,8 @@ Commands* vm_next_normal(Statements* restrict stmts, Commands* restrict cmds, Vm
     cmds = vm_command_next(stmts, cmds, vm);
 
     if (!vm->end) {
-        if ((cmds->prev_op == OP_PIPE || cmds->current_op == OP_PIPE)) {
+        // TODO: is this check redundant?
+        if (cmds->prev_op == OP_PIPE) {
             vm->op_current = OP_PIPE;
         }
         else {
@@ -607,9 +608,7 @@ int vm_run(Statements* restrict stmts, Shell* restrict shell, Arena* restrict sc
 [[nodiscard]]
 int vm_execute(Statements* restrict stmts, Shell* restrict shell, Arena* restrict scratch)
 {
-    assert(shell);
-    assert(stmts);
-
+    assert(shell); assert(stmts); assert(scratch);
     if (!stmts || !stmts->count) {
         return EXIT_SUCCESS;
     }
@@ -633,7 +632,7 @@ int vm_execute(Statements* restrict stmts, Shell* restrict shell, Arena* restric
 [[nodiscard]]
 int vm_execute_noninteractive(Statements* restrict stmts, Shell* restrict shell)
 {
-    assert(stmts);
+    assert(shell); assert(stmts);
     if (!stmts || !stmts->count) {
         return EXIT_SUCCESS;
     }

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -130,13 +130,13 @@ int vm_math_process(Vm_Data* restrict vm)
     while (*buf && printf("%s\n", *buf) && ++buf);
 #endif
 
-    if (!vm->buffer || !vm->buffer[0] || !vm->buffer[2]) {
+    if (!vm->strs || !vm->strs[0].value || !vm->strs[2].value) {
         return EXIT_FAILURE_CONTINUE;
     }
 
-    char* c1 = vm->buffer[0];
+    char* c1 = vm->strs[0].value;
     enum Ops op = vm->op_current;
-    char* c2 = vm->buffer[2];
+    char* c2 = vm->strs[2].value;
     assert(c1); assert(c2);
 
     bool result;
@@ -166,7 +166,7 @@ int vm_math_process(Vm_Data* restrict vm)
 [[nodiscard]]
 Commands* vm_command_next(Statements* restrict stmts, Commands* restrict cmds, Vm_Data* restrict vm)
 {
-    if (!cmds->next || !cmds->next->vals[0]) {
+    if (!cmds->next || !cmds->next->strs[0].value) {
         ++stmts->pos;
         if (stmts->pos >= stmts->count || stmts->pos >= stmts->cap) {
             debugf("hit stmts->count %zu or stmts->cap %zu, marking vm end\n", stmts->count, stmts->cap);
@@ -199,8 +199,8 @@ Commands* vm_command_next(Statements* restrict stmts, Commands* restrict cmds, V
 [[nodiscard]]
 Commands* vm_command_set(Statements* restrict stmts, Commands* restrict cmds, Vm_Data* restrict vm, enum Vm_State state)
 {
-    vm->buffer = cmds->vals;
-    vm->buffer_lens = cmds->lens;
+    vm->strs = cmds->strs;
+    vm->strs_n = cmds->count;
     vm->state = state;
     vm->op_current = cmds->prev_op;
     return vm_command_next(stmts, cmds, vm);
@@ -487,8 +487,8 @@ Commands* vm_next_normal(Statements* restrict stmts, Commands* restrict cmds, Vm
         return NULL;
     }
 
-    vm->buffer = cmds->vals;
-    vm->buffer_lens = cmds->lens;
+    vm->strs = cmds->strs;
+    vm->strs_n = cmds->count;
     cmds = vm_command_next(stmts, cmds, vm);
 
     if (!vm->end) {
@@ -545,7 +545,7 @@ int vm_run(Statements* restrict stmts, Shell* restrict shell, Arena* restrict sc
     while (!vm.end && cmds) {
         cmds = vm_next(stmts, cmds, &vm);
 
-        if (!vm.buffer || !vm.buffer[0]) {
+        if (!vm.strs || !vm.strs[0].value) {
             return EXIT_FAILURE_CONTINUE;
         }
 
@@ -575,7 +575,8 @@ int vm_run(Statements* restrict stmts, Shell* restrict shell, Arena* restrict sc
                 if (vm.op_current == OP_PIPE)
                     pipe_connect(vm.command_position, stmts->pipes_count, &vm.pipes_io);
 
-                vm.exec_result = execvp(vm.buffer[0], vm.buffer);
+                char** buffers = estrtoarr(vm.strs, vm.strs_n, scratch);
+                vm.exec_result = execvp(buffers[0], buffers);
                 if (vm.exec_result == EXECVP_FAILED) {
                     vm.end = true;
                     tty_perror("ncsh: Could not run command");

--- a/src/interpreter/vm_types.h
+++ b/src/interpreter/vm_types.h
@@ -7,6 +7,7 @@
 #include <stddef.h>
 
 #include "ops.h"
+#include "../eskilib/str.h"
 
 /****** MACROS ******/
 
@@ -56,8 +57,8 @@ typedef struct {
  * Stores information related to state in the VM.
  * Used in conjunction with Args and then Tokens. */
 typedef struct {
-    char** buffer;
-    size_t* buffer_lens;
+    size_t strs_n;
+    Str* strs;
     uint8_t command_position;
     bool end;
 

--- a/src/io/history.c
+++ b/src/io/history.c
@@ -377,9 +377,9 @@ int history_command_clean(History* restrict history, Arena* restrict arena, Aren
 }
 
 [[nodiscard]]
-int history_command_add(char* restrict value, size_t value_len, History* restrict history, Arena* restrict arena)
+int history_command_add(Str val, History* restrict history, Arena* restrict arena)
 {
-    return history_add(value, value_len, history, arena);
+    return history_add(val.value, val.length, history, arena);
 }
 
 void history_remove_entries_shift(size_t offset, History* restrict history)
@@ -392,12 +392,10 @@ void history_remove_entries_shift(size_t offset, History* restrict history)
 }
 
 [[nodiscard]]
-int history_command_remove(char* restrict value, size_t value_len, History* restrict history, Arena* restrict arena,
+int history_command_remove(Str val, History* restrict history, Arena* restrict arena,
                            Arena* restrict scratch)
 {
-    assert(value);
-    assert(value_len > 0);
-    assert(history);
+    assert(val.value); assert(val.length > 0); assert(history);
 
     if (history_clean(history, arena, *scratch) != E_SUCCESS) {
         return EXIT_FAILURE_CONTINUE;
@@ -405,12 +403,12 @@ int history_command_remove(char* restrict value, size_t value_len, History* rest
 
     // TODO: is this even needed? didn't we reload history in history clean?
     for (size_t i = 0; i < history->count; ++i) {
-        if (estrcmp(history->entries[i].value, history->entries[i].length, value, value_len)) {
+        if (estrcmp(history->entries[i], val)) {
             history->entries[i].value = NULL;
             history->entries[i].length = 0;
             history_remove_entries_shift(i, history);
             --history->count;
-            tty_print("ncsh history: removed entry: %s\n", value);
+            tty_print("ncsh history: removed entry: %s\n", val.value);
             return EXIT_SUCCESS;
         }
     }

--- a/src/io/history.h
+++ b/src/io/history.h
@@ -18,7 +18,7 @@
 
 typedef struct {
     size_t count;
-    char* file;
+    Str file;
     Str* entries;
 } History;
 

--- a/src/io/history.h
+++ b/src/io/history.h
@@ -40,7 +40,7 @@ int history_command_count(History* restrict history);
 
 int history_command_clean(History* restrict history, Arena* restrict arena, Arena* restrict scratch_arena);
 
-int history_command_add(char* restrict value, size_t value_len, History* restrict history, Arena* restrict arena);
+int history_command_add(Str val, History* restrict history, Arena* restrict arena);
 
-int history_command_remove(char* restrict value, size_t value_len, History* restrict history, Arena* restrict arena,
+int history_command_remove(Str val, History* restrict history, Arena* restrict arena,
                            Arena* restrict scratch_arena);

--- a/src/io/io.c
+++ b/src/io/io.c
@@ -13,7 +13,6 @@
 #define AUTOCOMPLETE_DIM 244
 
 extern volatile int sigwinch_caught;
-extern volatile int sigint_caught;
 
 void io_prompt_init()
 {
@@ -71,7 +70,7 @@ int io_init(Config* restrict config, Env* restrict env, Input* restrict input, A
  */
 void io_deinit(Input* restrict input, Arena scratch)
 {
-    if (input && input->history.file && input->history.entries) {
+    if (input && input->history.file.value && input->history.entries) {
         history_save(&input->history, &scratch);
     }
 }
@@ -1060,9 +1059,6 @@ int io_readline(Input* restrict input, Arena* restrict scratch)
         if (sigwinch_caught) {
             io_resize(input);
             sigwinch_caught = 0;
-        }
-        if (sigint_caught) {
-            input->reprint_prompt = true;
         }
 
         io_autocomplete(input);

--- a/src/signals.h
+++ b/src/signals.h
@@ -12,7 +12,6 @@
 
 extern sig_atomic_t vm_child_pid;
 extern volatile int sigwinch_caught;
-extern volatile int sigint_caught;
 
 static void signal_handler(int sig, [[maybe_unused]] siginfo_t* info, [[maybe_unused]] void* context)
 {
@@ -24,9 +23,6 @@ static void signal_handler(int sig, [[maybe_unused]] siginfo_t* info, [[maybe_un
     if (sig == SIGINT || sig == SIGQUIT) {
         if (vm_child_pid != 0) {
             kill(vm_child_pid, sig);
-        }
-        else {
-            sigint_caught = 1;
         }
         return;
     }

--- a/src/types.h
+++ b/src/types.h
@@ -77,7 +77,7 @@ typedef struct {
  */
 typedef struct Shell {
     Arena arena;
-    Arena scratch_arena;
+    Arena scratch;
 
     Env* env;
     Config config;

--- a/src/z/z.c
+++ b/src/z/z.c
@@ -13,14 +13,14 @@
 #include <unistd.h>
 
 #include "../defines.h" // used for NCSH_MAX_INPUT
+// #include "../env.h"
 #include "../ttyio/ttyio.h"
 #include "fzf.h"
 #include "z.h"
 
 double z_score(z_Directory* restrict directory, int fzf_score, time_t now)
 {
-    assert(directory);
-    assert(fzf_score > 0);
+    assert(directory); assert(fzf_score > 0);
 
     time_t duration = now - directory->last_accessed;
 
@@ -38,12 +38,12 @@ double z_score(z_Directory* restrict directory, int fzf_score, time_t now)
     }
 }
 
-bool z_match_exists(char* restrict target, size_t target_length, z_Database* restrict db)
+bool z_match_exists(Str* restrict target, z_Database* restrict db)
 {
-    assert(db && target && target_length > 0);
+    assert(db); assert(target); assert(target->value); assert(target->length > 0);
 
     for (size_t i = 0; i < db->count; ++i) {
-        if (estrcmp((db->dirs + i)->path, (db->dirs + i)->path_length, target, target_length)) {
+        if (estrcmp_s(*target, (db->dirs + i)->path, (db->dirs + i)->path_length)) {
             ++(db->dirs + i)->rank;
             (db->dirs + i)->last_accessed = time(NULL);
             return true;
@@ -53,16 +53,16 @@ bool z_match_exists(char* restrict target, size_t target_length, z_Database* res
     return false;
 }
 
-z_Directory* z_match_find(char* restrict target, size_t target_length, char* restrict cwd, size_t cwd_length, z_Database* restrict db,
+z_Directory* z_match_find(Str* restrict target, char* restrict cwd, size_t cwd_length, z_Database* restrict db,
                           Arena* restrict scratch_arena)
 {
-    assert(target && target_length && cwd && cwd_length && scratch_arena && db);
+    assert(target); assert(target->value); assert(target->length); assert(cwd); assert(cwd_length);
     if (!db->count || cwd_length < 2) {
         return NULL;
     }
 
     fzf_slab_t* slab = fzf_make_slab((fzf_slab_config_t){(size_t)1 << 6, 1 << 6}, scratch_arena);
-    fzf_pattern_t* pattern = fzf_parse_pattern(target, target_length - 1, scratch_arena);
+    fzf_pattern_t* pattern = fzf_parse_pattern(target->value, target->length - 1, scratch_arena);
     z_Match current_match = {0};
     time_t now = time(NULL);
 #ifdef Z_DEBUG
@@ -70,7 +70,7 @@ z_Directory* z_match_find(char* restrict target, size_t target_length, char* res
 #endif
 
     for (size_t i = 0; i < db->count; ++i) {
-        if (!estrcmp((db->dirs + i)->path, (db->dirs + i)->path_length, cwd, cwd_length)) {
+        if (!estrcmp_a((db->dirs + i)->path, (db->dirs + i)->path_length, cwd, cwd_length)) {
             int fzf_score =
                 fzf_get_score((db->dirs + i)->path, (db->dirs + i)->path_length - 1, pattern, slab, scratch_arena);
             if (!fzf_score)
@@ -286,20 +286,19 @@ enum z_Result z_read(z_Database* restrict db, Arena* restrict arena)
     return Z_SUCCESS;
 }
 
-enum z_Result z_write_entry_new(char* restrict path, size_t path_length, z_Database* restrict db, Arena* restrict arena)
+enum z_Result z_write_entry_new(Str* restrict path, z_Database* restrict db, Arena* restrict arena)
 {
-    assert(path && db && path_length > 1);
-    assert(path[path_length - 1] == '\0');
+    assert(path); assert(path->value); assert(db); assert(path->length > 1); assert(path->value[path->length - 1] == '\0');
     if (db->count == Z_DATABASE_IN_MEMORY_LIMIT) {
         return Z_FAILURE;
     }
 
-    db->dirs[db->count].path = arena_malloc(arena, path_length, char);
+    db->dirs[db->count].path = arena_malloc(arena, path->length, char);
 
-    memcpy(db->dirs[db->count].path, path, path_length);
-    assert(db->dirs[db->count].path[path_length - 1] == '\0');
+    memcpy(db->dirs[db->count].path, path, path->length);
+    assert(db->dirs[db->count].path[path->length - 1] == '\0');
 
-    db->dirs[db->count].path_length = path_length;
+    db->dirs[db->count].path_length = path->length;
     ++db->dirs[db->count].rank;
     db->dirs[db->count].last_accessed = time(NULL);
     ++db->count;
@@ -307,11 +306,11 @@ enum z_Result z_write_entry_new(char* restrict path, size_t path_length, z_Datab
     return Z_SUCCESS;
 }
 
-enum z_Result z_database_add(char* restrict path, size_t path_length, char* restrict cwd, size_t cwd_length, z_Database* restrict db,
+enum z_Result z_database_add(Str* restrict path, char* restrict cwd, size_t cwd_length, z_Database* restrict db,
                              Arena* restrict arena)
 {
-    assert(db && arena);
-    if (!path || !path_length) {
+    assert(db); assert(arena);
+    if (!path || !path->value || !path->length) {
         return Z_NULL_REFERENCE;
     }
 
@@ -319,19 +318,19 @@ enum z_Result z_database_add(char* restrict path, size_t path_length, char* rest
         return Z_HIT_MEMORY_LIMIT;
     }
 
-    assert(path && path[path_length - 1] == '\0');
-    assert(strlen(path) + 1 == path_length);
+    assert(path && path->value[path->length - 1] == '\0');
+    assert(strlen(path->value) + 1 == path->length);
     assert(cwd && cwd[cwd_length - 1] == '\0');
     assert(strlen(cwd) + 1 == cwd_length);
 
-    size_t total_length = path_length + cwd_length;
+    size_t total_length = path->length + cwd_length;
     assert(total_length > 0);
 
     db->dirs[db->count].path = arena_malloc(arena, total_length, char);
 
     memcpy(db->dirs[db->count].path, cwd, cwd_length);
     db->dirs[db->count].path[cwd_length - 1] = '/';
-    memcpy(db->dirs[db->count].path + cwd_length, path, path_length);
+    memcpy(db->dirs[db->count].path + cwd_length, path, path->length);
 
     assert(strlen(db->dirs[db->count].path) + 1 == total_length);
     assert(db->dirs[db->count].path[total_length - 1] == '\0');
@@ -405,10 +404,10 @@ bool z_is_dir(struct dirent* restrict dir)
     return !stat(dir->d_name, &sb) && S_ISDIR(sb.st_mode);
 }
 
-enum z_Result z_directory_match_exists(char* restrict target, size_t target_length, char* restrict cwd, Str* restrict output,
+enum z_Result z_directory_match_exists(Str* restrict target, char* restrict cwd, Str* restrict output,
                                        Arena* restrict scratch_arena)
 {
-    assert(target && cwd && target_length > 0);
+    assert(target); assert(cwd); assert(target->length > 0);
 
     struct dirent* dir;
     DIR* current_dir = opendir(cwd);
@@ -429,12 +428,12 @@ enum z_Result z_directory_match_exists(char* restrict target, size_t target_leng
         dir_len = strlen(dir->d_name) + 1;
 #endif /* _DIRENT_HAVE_D_RECLEN */
 
-        if (z_is_dir(dir) && estrcmp(dir->d_name, dir_len, target, target_length)) {
+        if (z_is_dir(dir) && estrcmp_s(*target, dir->d_name, dir_len)) {
             output->value = arena_malloc(scratch_arena, dir_len, char);
             output->length = dir_len;
             memcpy(output->value, dir->d_name, dir_len);
 
-            if ((closedir(current_dir)) == -1) {
+            if ((closedir(current_dir)) == EOF) {
                 tty_perror("z: could not close directory");
                 return Z_FAILURE;
             }
@@ -443,7 +442,7 @@ enum z_Result z_directory_match_exists(char* restrict target, size_t target_leng
         }
     }
 
-    if ((closedir(current_dir)) == -1) {
+    if ((closedir(current_dir)) == EOF) {
         tty_perror("z: could not close directory");
         return Z_FAILURE;
     }
@@ -451,12 +450,13 @@ enum z_Result z_directory_match_exists(char* restrict target, size_t target_leng
     return Z_MATCH_NOT_FOUND;
 }
 
-void z(char* restrict target, size_t target_length, char* restrict cwd, z_Database* restrict db, Arena* restrict arena, Arena scratch_arena)
+void z(Str* restrict target, char* restrict cwd, z_Database* restrict db, Arena* restrict arena, Arena scratch_arena)
 {
 #ifdef Z_DEBUG
     tty_println("z: %s", target);
 #endif /* ifdef Z_DEBUG */
 
+    // TODO: use env.h
     char* home = getenv("HOME");
     if (!home) {
         tty_perror("z: couldn't get HOME from environment");
@@ -464,7 +464,7 @@ void z(char* restrict target, size_t target_length, char* restrict cwd, z_Databa
 
     if (!target) {
         if (home) {
-            if (chdir(home) == -1) {
+            if (chdir(home) == EOF) {
                 tty_perror("z: couldn't change directory to home");
             }
         }
@@ -472,17 +472,17 @@ void z(char* restrict target, size_t target_length, char* restrict cwd, z_Databa
         return;
     }
 
-    assert(target_length && cwd && db && arena && scratch_arena.start);
-    if (!cwd || !db || target_length < 2) {
+    assert(target->length && cwd && db && arena && scratch_arena.start);
+    if (!cwd || !db || target->length < 2) {
         return;
     }
-    assert(!target[target_length - 1]);
-    if (target[target_length - 1]) {
+    assert(!target->value[target->length - 1]);
+    if (target->value[target->length - 1]) {
         return;
     }
 
-    if (estrcmp(target, target_length, home, strlen(home) + 1)) {
-        if (chdir(home) == -1) {
+    if (estrcmp_s(*target, home, strlen(home) + 1)) {
+        if (chdir(home) == EOF) {
             tty_perror("z: couldn't change directory to home");
         }
 
@@ -490,16 +490,16 @@ void z(char* restrict target, size_t target_length, char* restrict cwd, z_Databa
     }
 
     // handle z .
-    if (target_length == 2 && target[0] == '.') {
-        if (chdir(target) == -1) {
+    if (target->length == 2 && target->value[0] == '.') {
+        if (chdir(target->value) == EOF) {
             tty_perror("z: couldn't change directory (1)");
         }
 
         return;
     }
     // handle z ..
-    else if (target_length == 3 && target[0] == '.' && target[1] == '.') {
-        if (chdir(target) == -1) {
+    else if (target->length == 3 && target->value[0] == '.' && target->value[1] == '.') {
+        if (chdir(target->value) == EOF) {
             tty_perror("z: couldn't change directory (2)");
         }
 
@@ -508,14 +508,14 @@ void z(char* restrict target, size_t target_length, char* restrict cwd, z_Databa
 
     size_t cwd_length = strlen(cwd) + 1;
     Str output = {0};
-    z_Directory* match = z_match_find(target, target_length, cwd, cwd_length, db, &scratch_arena);
+    z_Directory* match = z_match_find(target, cwd, cwd_length, db, &scratch_arena);
 
-    if (z_directory_match_exists(target, target_length, cwd, &output, &scratch_arena) == Z_SUCCESS) {
+    if (z_directory_match_exists(target, cwd, &output, &scratch_arena) == Z_SUCCESS) {
 #ifdef Z_DEBUG
         tty_println("dir matches %s", output.value);
 #endif /* ifdef Z_DEBUG */
 
-        if (chdir(output.value) == -1) {
+        if (chdir(output.value) == EOF) {
             if (!match) {
                 tty_perror("z: couldn't change directory (3)");
                 return;
@@ -523,19 +523,19 @@ void z(char* restrict target, size_t target_length, char* restrict cwd, z_Databa
         }
 
         if (!match) {
-            z_database_add(output.value, output.length, cwd, cwd_length, db, arena);
+            z_database_add(&output, cwd, cwd_length, db, arena);
             return;
         }
     }
 
     if (match && match->path) {
         // try to change to the match first, if that doesn't work try target
-        if (chdir(match->path) == -1) {
-            if (chdir(target) == -1) {
+        if (chdir(match->path) == EOF) {
+            if (chdir(target->value) == EOF) {
                 tty_perror("z: couldn't change directory (4)");
                 return;
             }
-            z_database_add(target, target_length, cwd, cwd_length, db, arena);
+            z_database_add(target, cwd, cwd_length, db, arena);
             return;
         }
 
@@ -544,35 +544,35 @@ void z(char* restrict target, size_t target_length, char* restrict cwd, z_Databa
         return;
     }
 
-    if (chdir(target) == -1) {
+    if (chdir(target->value) == EOF) {
         tty_perror("z: couldn't change directory");
         return;
     }
 
-    z_database_add(target, target_length, cwd, cwd_length, db, arena);
+    z_database_add(target, cwd, cwd_length, db, arena);
 }
 
 #define Z_ENTRY_EXISTS_MESSAGE "z: Entry already exists in z database."
 #define Z_ADDED_NEW_ENTRY_MESSAGE "z: Added new entry to z database."
 #define Z_ERROR_ADDING_ENTRY_MESSAGE "z: Error adding new entry to z database."
 
-enum z_Result z_add(char* restrict path, size_t path_length, z_Database* restrict db, Arena* restrict arena)
+enum z_Result z_add(Str* restrict path, z_Database* restrict db, Arena* restrict arena)
 {
-    if (!path || !db) {
+    if (!path || !path->value || !db) {
         tty_fputs("z: Null value passed to z add.", stderr);
         return Z_NULL_REFERENCE;
     }
-    if (path_length < 2 || path[path_length - 1] != '\0') {
+    if (path->length < 2 || path->value[path->length - 1] != '\0') {
         tty_fputs("z: Bad string passed to z add.", stderr);
         return Z_BAD_STRING;
     }
 
-    if (z_match_exists(path, path_length, db)) {
+    if (z_match_exists(path, db)) {
         tty_writeln(Z_ENTRY_EXISTS_MESSAGE, sizeof(Z_ENTRY_EXISTS_MESSAGE) - 1);
         return Z_SUCCESS;
     }
 
-    if (z_write_entry_new(path, path_length, db, arena) == Z_SUCCESS) {
+    if (z_write_entry_new(path, db, arena) == Z_SUCCESS) {
         tty_writeln(Z_ADDED_NEW_ENTRY_MESSAGE, sizeof(Z_ADDED_NEW_ENTRY_MESSAGE) - 1);
         return Z_SUCCESS;
     }
@@ -594,21 +594,21 @@ void z_remove_dirs_shift(size_t offset, z_Database* restrict db)
 
 #define Z_ENTRY_NOT_FOUND_MESSAGE "z: Entry could not be found in z database."
 #define Z_ENTRY_REMOVED_MESSAGE "z: Removed entry from z database."
-enum z_Result z_remove(char* restrict path, size_t path_length, z_Database* restrict db)
+enum z_Result z_remove(Str* restrict path, z_Database* restrict db)
 {
     assert(db);
 
-    if (!path) {
+    if (!path || !path->value) {
         tty_fputs("z: Null value passed to z rm/remove.", stderr);
         return Z_NULL_REFERENCE;
     }
-    if (path_length < 2 || path[path_length - 1] != '\0') {
+    if (path->length < 2 || path->value[path->length - 1] != '\0') {
         tty_fputs("z: Bad string passed to z rm/remove.", stderr);
         return Z_BAD_STRING;
     }
 
     for (size_t i = 0; i < db->count; ++i) {
-        if (estrcmp((db->dirs + i)->path, (db->dirs + i)->path_length, (char*)path, path_length)) {
+        if (estrcmp_s(*path, (db->dirs + i)->path, (db->dirs + i)->path_length)) {
             (db->dirs + i)->path = NULL;
             (db->dirs + i)->path_length = 0;
             (db->dirs + i)->last_accessed = 0;

--- a/src/z/z.c
+++ b/src/z/z.c
@@ -572,9 +572,6 @@ void z_remove_dirs_shift(size_t offset, z_Database* restrict db)
     }
 
     memmove(db->dirs + offset, db->dirs + offset + 1, db->count - 1);
-    /*for (size_t i = offset; i < db->count - 1; ++i) {
-        db->dirs[i] = db->dirs[i + 1];
-    }*/
 }
 
 #define Z_ENTRY_NOT_FOUND_MESSAGE "z: Entry could not be found in z database."

--- a/src/z/z.h
+++ b/src/z/z.h
@@ -57,12 +57,12 @@ enum z_Result {
 
 enum z_Result z_init(Str* restrict config_location, z_Database* restrict database, Arena* restrict arena);
 
-void z(char* restrict target, size_t target_length, char* restrict cwd, z_Database* restrict db, Arena* restrict arena,
+void z(Str* restrict str, char* restrict cwd, z_Database* restrict db, Arena* restrict arena,
        Arena scratch_arena);
 
-enum z_Result z_add(char* restrict path, size_t path_length, z_Database* restrict db, Arena* restrict arena);
+enum z_Result z_add(Str* restrict path, z_Database* restrict db, Arena* restrict arena);
 
-enum z_Result z_remove(char* restrict path, size_t path_length, z_Database* restrict db);
+enum z_Result z_remove(Str* restrict path, z_Database* restrict db);
 
 enum z_Result z_exit(z_Database* restrict db);
 

--- a/src/z/z.h
+++ b/src/z/z.h
@@ -24,8 +24,7 @@
 typedef struct {
     double rank;
     time_t last_accessed;
-    char* path;
-    size_t path_length;
+    Str path;
 } z_Directory;
 
 typedef struct {

--- a/tests/alias_tests.c
+++ b/tests/alias_tests.c
@@ -4,12 +4,11 @@
 #include "etest.h"
 #include "lib/arena_test_helper.h"
 
-Arena* test_arena;
+static Arena* ar;
 
 void alias_check_no_alias_test()
 {
-    char buffer[] = "echo hello";
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(Str_New_Literal("echo hello"));
 
     eassert(!result.length);
     eassert(!result.value);
@@ -17,12 +16,10 @@ void alias_check_no_alias_test()
 
 void alias_add_then_check_alias_found_test()
 {
-    char* alias = "n=nvim";
-    size_t alias_len = strlen(alias) + 1;
-    alias_add(alias, alias_len, test_arena);
+    Str alias = Str_New_Literal("n=nvim");
+    alias_add(alias, ar);
 
-    char buffer[] = "n";
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(Str_New_Literal("n"));
 
     char expected_result[] = "nvim";
     eassert(result.length == sizeof(expected_result));
@@ -31,10 +28,10 @@ void alias_add_then_check_alias_found_test()
 
 void alias_add_new_then_check_alias_found_test()
 {
-    alias_add_new("n", 2, "nvim", 5, test_arena);
+    Str alias = Str_New_Literal("n");
+    alias_add_new(alias, Str_New_Literal("nvim"), ar);
 
-    char buffer[] = "n";
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(alias);
 
     char expected_result[] = "nvim";
     eassert(result.length == sizeof(expected_result));
@@ -43,12 +40,10 @@ void alias_add_new_then_check_alias_found_test()
 
 void alias_add_then_check_alias_found_multiple_chars_test()
 {
-    char* alias = "fd=fdfind";
-    size_t alias_len = strlen(alias) + 1;
-    alias_add(alias, alias_len, test_arena);
+    Str alias = Str_New_Literal("fd=fdfind");
+    alias_add(alias, ar);
 
-    char buffer[] = "fd";
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(Str_New_Literal("fd"));
 
     char expected_result[] = "fdfind";
     eassert(result.length == sizeof(expected_result));
@@ -57,10 +52,10 @@ void alias_add_then_check_alias_found_multiple_chars_test()
 
 void alias_add_new_then_check_alias_found_multiple_chars_test()
 {
-    alias_add_new("fd", 3, "fdfind", 7, test_arena);
+    Str alias = Str_New_Literal("fd");
+    alias_add_new(alias, Str_New_Literal("fdfind"), ar);
 
-    char buffer[] = "fd";
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(alias);
 
     char expected_result[] = "fdfind";
     eassert(result.length == sizeof(expected_result));
@@ -69,28 +64,25 @@ void alias_add_new_then_check_alias_found_multiple_chars_test()
 
 void alias_add_then_remove_test()
 {
-    char* alias = "n=nvim";
-    size_t alias_len = strlen(alias) + 1;
-    alias_add(alias, alias_len, test_arena);
+    Str alias = Str_New_Literal("n=nvim");
+    alias_add(alias, ar);
 
-    char buffer[] = "nvim";
-    alias_remove(buffer, sizeof(buffer));
+    Str buffer = Str_New_Literal("nvim");
+    alias_remove(buffer);
 
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(buffer);
     eassert(result.length == 0);
     eassert(result.value == NULL);
 }
 
 void alias_add_then_delete_test()
 {
-    char* alias = "n=nvim";
-    size_t alias_len = strlen(alias) + 1;
-    alias_add(alias, alias_len, test_arena);
+    Str alias = Str_New_Literal("n=nvim");
+    alias_add(alias, ar);
 
     alias_delete();
 
-    char buffer[] = "nvim";
-    Str result = alias_check(buffer, sizeof(buffer));
+    Str result = alias_check(Str_New_Literal("n"));
     eassert(result.length == 0);
     eassert(result.value == NULL);
 }
@@ -98,7 +90,7 @@ void alias_add_then_delete_test()
 void alias_tests()
 {
     ARENA_TEST_SETUP;
-    test_arena = &arena;
+    ar = &arena;
 
     etest_start();
 

--- a/tests/conf_tests.c
+++ b/tests/conf_tests.c
@@ -15,7 +15,7 @@ void conf_init_test()
 
     Shell shell = {0};
     shell_init(&shell, &arena, envp_ptr);
-    conf_init(&shell);
+    conf_init(&shell, s);
 
     eassert(shell.config.file.value);
     eassert(shell.config.location.value);

--- a/tests/eskilib/str_tests.c
+++ b/tests/eskilib/str_tests.c
@@ -9,21 +9,38 @@
 void estrcmp_no_length_test()
 {
     char* val = "";
-    bool result = estrcmp(val, 0, "", 0);
+    bool result = estrcmp(Str_New(val, 0), Str_New("", 0));
+    eassert(!result);
+}
+
+void estrcmp_a_no_length_test()
+{
+    char* val = "";
+    bool result = estrcmp_a(val, 0, "", 0);
     eassert(!result);
 }
 
 void estrcmp_null_test()
 {
-    bool result = estrcmp(NULL, 0, NULL, 0);
+    bool result = estrcmp(Str_Empty, Str_Empty);
+    eassert(!result);
+}
+
+void estrcmp_a_null_test()
+{
+    bool result = estrcmp_a(NULL, 0, NULL, 0);
     eassert(!result);
 }
 
 void estrcmp_s1_null_test()
 {
-    char* val = "hello";
-    constexpr size_t len = sizeof("hello") - 1;
-    bool result = estrcmp(NULL, 0, val, len);
+    bool result = estrcmp(Str_Empty, Str_New_Literal("hello"));
+    eassert(!result);
+}
+
+void estrcmp_a_s1_null_test()
+{
+    bool result = estrcmp_a(NULL, 0, "hello", sizeof("hello"));
     eassert(!result);
 }
 
@@ -31,15 +48,30 @@ void estrcmp_empty_string_test()
 {
     Str str = Str_Empty;
     Str str2 = Str_Empty;
-    bool result = estrcmp(str.value, str.length, str2.value, str2.length);
+    bool result = estrcmp(str, str2);
+    eassert(!result);
+}
+
+void estrcmp_a_empty_string_test()
+{
+    Str str = Str_Empty;
+    Str str2 = Str_Empty;
+    bool result = estrcmp_a(str.value, str.length, str2.value, str2.length);
     eassert(!result);
 }
 
 void estrcmp_true_test()
 {
+    Str val = Str_New_Literal("hello");
+    bool result = estrcmp(val, Str_New_Literal("hello"));
+    eassert(result);
+}
+
+void estrcmp_a_true_test()
+{
     char* val = "hello";
     constexpr size_t len = sizeof("hello") - 1;
-    bool result = estrcmp(val, len, "hello", len);
+    bool result = estrcmp_a(val, len, "hello", len);
     eassert(result);
 }
 
@@ -48,19 +80,36 @@ void estrcmp_false_test()
     Str s1 = Str_New_Literal("hello hello");
     Str s2 = Str_New_Literal("hello there");
 
-    bool result = estrcmp(s1.value, s1.length, s2.value, s2.length);
+    bool result = estrcmp(s1, s2);
+
+    eassert(!result);
+}
+
+void estrcmp_a_false_test()
+{
+    Str s1 = Str_New_Literal("hello hello");
+    Str s2 = Str_New_Literal("hello there");
+
+    bool result = estrcmp_a(s1.value, s1.length, s2.value, s2.length);
 
     eassert(!result);
 }
 
 void estrcmp_mismatched_lengths_false_test()
 {
+    bool result = estrcmp(Str_New_Literal("hello"), Str_New_Literal("hello there"));
+
+    eassert(!result);
+}
+
+void estrcmp_a_mismatched_lengths_false_test()
+{
     char* val = "hello";
     constexpr size_t len = sizeof("hello");
     char* val_two = "hello there";
     constexpr size_t len_two = sizeof("hello there");
 
-    bool result = estrcmp(val, len, val_two, len_two);
+    bool result = estrcmp_a(val, len, val_two, len_two);
 
     eassert(!result);
 }
@@ -70,7 +119,16 @@ void estrcmp_partial_comparison_true_test()
     char* val = "hello";
     // only compare the first three characters, 'hel'
     constexpr size_t len = sizeof("hello") - 1 - 2;
-    bool result = estrcmp(val, len, "hello", len);
+    bool result = estrcmp(Str_New(val, len), Str_New("hello", len));
+    eassert(result);
+}
+
+void estrcmp_a_partial_comparison_true_test()
+{
+    char* val = "hello";
+    // only compare the first three characters, 'hel'
+    constexpr size_t len = sizeof("hello") - 1 - 2;
+    bool result = estrcmp_a(val, len, "hello", len);
     eassert(result);
 }
 
@@ -79,7 +137,17 @@ void estrcmp_partial_comparison_false_test()
     Str s1 = Str_New("hello hello", sizeof("hello hello") - 2);
     Str s2 = Str_New("hello there", sizeof("hello there") - 2);
 
-    bool result = estrcmp(s1.value, s1.length, s2.value, s2.length);
+    bool result = estrcmp(s1, s2);
+
+    eassert(!result);
+}
+
+void estrcmp_a_partial_comparison_false_test()
+{
+    Str s1 = Str_New("hello hello", sizeof("hello hello") - 2);
+    Str s2 = Str_New("hello there", sizeof("hello there") - 2);
+
+    bool result = estrcmp_a(s1.value, s1.length, s2.value, s2.length);
 
     eassert(!result);
 }
@@ -228,6 +296,13 @@ void estrcat_valid_values_returns_concatted_str_test()
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
 
+void estridx_returns_idx_test()
+{
+    size_t idx = estridx(&Str_New_Literal("vim=nvim"), '=');
+
+    eassert(idx == 3);
+}
+
 void str_tests()
 {
     etest_start();
@@ -242,6 +317,16 @@ void str_tests()
     etest_run(estrcmp_partial_comparison_true_test);
     etest_run(estrcmp_partial_comparison_false_test);
 
+    etest_run(estrcmp_a_no_length_test);
+    etest_run(estrcmp_a_null_test);
+    etest_run(estrcmp_a_s1_null_test);
+    etest_run(estrcmp_a_empty_string_test);
+    etest_run(estrcmp_a_true_test);
+    etest_run(estrcmp_a_false_test);
+    etest_run(estrcmp_a_mismatched_lengths_false_test);
+    etest_run(estrcmp_a_partial_comparison_true_test);
+    etest_run(estrcmp_a_partial_comparison_false_test);
+
     etest_run(estrsplit_bad_value_returns_null_test);
     etest_run(estrsplit_last_pos_splitter_returns_null_test);
     etest_run(estrsplit_valid_input_returns_strs_test);
@@ -255,6 +340,8 @@ void str_tests()
     etest_run(estrcat_bad_value_returns_null_test);
     etest_run(estrcat_one_bad_value_returns_null_test);
     etest_run(estrcat_other_bad_value_returns_null_test);
+
+    etest_run(estridx_returns_idx_test);
 
     etest_finish();
 }

--- a/tests/eskilib/str_tests.c
+++ b/tests/eskilib/str_tests.c
@@ -413,6 +413,88 @@ void sb_multiple_realloc_test()
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
 
+void sb_joined_test()
+{
+    SCRATCH_ARENA_TEST_SETUP;
+    auto sb = sb_new(&s);
+    auto str = Str_New_Literal("ncsh");
+
+    sb_add(&str, sb, &s);
+    eassert(sb->n == 1);
+    auto res = sb_to_joined_str(sb, ':', &s);
+
+    eassert(res);
+    eassert(res->length == str.length);
+    eassert(!memcmp(res->value, str.value, str.length - 1));
+
+    SCRATCH_ARENA_TEST_TEARDOWN;
+}
+
+void sb_joined_many_test()
+{
+    SCRATCH_ARENA_TEST_SETUP;
+    auto sb = sb_new(&s);
+
+    sb_add(&Str_New_Literal("/home"), sb, &s);
+    eassert(sb->n == 1);
+    sb_add(&Str_New_Literal("alex"), sb, &s);
+    eassert(sb->n == 2);
+    sb_add(&Str_New_Literal("ncsh"), sb, &s);
+    eassert(sb->n == 3);
+    auto res = sb_to_joined_str(sb, '/', &s);
+
+    auto expected = Str_New_Literal("/home/alex/ncsh");
+    eassert(res);
+    eassert(res->length == expected.length);
+    eassert(!memcmp(res->value, expected.value, expected.length - 1));
+
+    SCRATCH_ARENA_TEST_TEARDOWN;
+}
+
+void sb_joined_realloc_test()
+{
+    SCRATCH_ARENA_TEST_SETUP;
+    auto sb = sb_new(&s);
+
+    auto str = &Str_New_Literal("alex");
+    for (size_t i = 0; i < 15; ++i) {
+        sb_add(str, sb, &s);
+        eassert(sb->n = i + 1);
+    }
+    eassert(sb->c = SB_START_N * 2);
+
+    auto res = sb_to_joined_str(sb, '/', &s);
+
+    auto expected = Str_New_Literal("alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex");
+    eassert(res);
+    eassert(res->length == expected.length);
+    eassert(!memcmp(res->value, expected.value, expected.length - 1));
+
+    SCRATCH_ARENA_TEST_TEARDOWN;
+}
+
+void sb_joined_multiple_realloc_test()
+{
+    SCRATCH_ARENA_TEST_SETUP;
+    auto sb = sb_new(&s);
+
+    auto str = &Str_New_Literal("alex");
+    for (size_t i = 0; i < 25; ++i) {
+        sb_add(str, sb, &s);
+        eassert(sb->n = i + 1);
+    }
+    eassert(sb->c = SB_START_N * 2 * 2);
+
+    auto res = sb_to_joined_str(sb, '/', &s);
+
+    auto expected = Str_New_Literal("alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex/alex");
+    eassert(res);
+    eassert(res->length == expected.length);
+    eassert(!memcmp(res->value, expected.value, expected.length - 1));
+
+    SCRATCH_ARENA_TEST_TEARDOWN;
+}
+
 void str_tests()
 {
     etest_start();
@@ -458,6 +540,12 @@ void str_tests()
     etest_run(sb_test);
     etest_run(sb_many_test);
     etest_run(sb_realloc_test);
+    etest_run(sb_multiple_realloc_test);
+
+    etest_run(sb_joined_test);
+    etest_run(sb_joined_many_test);
+    etest_run(sb_joined_realloc_test);
+    etest_run(sb_joined_multiple_realloc_test);
 
     etest_finish();
 }

--- a/tests/etest.h
+++ b/tests/etest.h
@@ -52,7 +52,7 @@ static int tests_passed;
 
 static bool abort_on_failed_assert;
 
-static void etest_init(bool abort_on_failed_assertion)
+[[maybe_unused]] static void etest_init(bool abort_on_failed_assertion)
 {
     abort_on_failed_assert = abort_on_failed_assertion;
 }

--- a/tests/etest.h
+++ b/tests/etest.h
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define RESET "\033[0m"
 #define RED "\033[31m"
@@ -49,6 +50,13 @@ static bool test_failed;
 static int tests_failed;
 static int tests_passed;
 
+static bool abort_on_failed_assert;
+
+static void etest_init(bool abort_on_failed_assertion)
+{
+    abort_on_failed_assert = abort_on_failed_assertion;
+}
+
 static void etest_run_internal(char* function_name, void (*function)(void))
 {
     test_failed = false;
@@ -69,6 +77,9 @@ static void etest_run_internal(char* function_name, void (*function)(void))
 [[maybe_unused]]
 static void etest_failed_internal(void)
 {
+    if (abort_on_failed_assert) {
+        abort();
+    }
     test_failed = true;
 }
 

--- a/tests/interpreter/expansions_tests.c
+++ b/tests/interpreter/expansions_tests.c
@@ -22,16 +22,16 @@ void expansion_home_test()
     Lexemes lexemes = {0};
     lexemes_init(&lexemes, &a);
     lexemes.count = 1;
-    lexemes.vals[0] = arena_malloc(&a, 2, char);
-    lexemes.vals[0][0] = '~';
-    lexemes.lens[0] = 2;
+    lexemes.strs[0].value = arena_malloc(&a, 2, char);
+    lexemes.strs[0].value[0] = '~';
+    lexemes.strs[0].length = 2;
     lexemes.ops[0] = OP_HOME_EXPANSION;
 
     expansion_home(&shell, &lexemes, 0, &a);
 
-    printf("%s\n", lexemes.vals[0]);
-    eassert(!memcmp(lexemes.vals[0], home, home_len - 1));
-    eassert(lexemes.lens[0] == home_len);
+    printf("%s\n", lexemes.strs[0].value);
+    eassert(!memcmp(lexemes.strs[0].value, home, home_len - 1));
+    eassert(lexemes.strs[0].length == home_len);
     eassert(lexemes.ops[0] == OP_CONSTANT);
 
     ARENA_TEST_TEARDOWN;
@@ -50,16 +50,16 @@ void expansion_home_suffix_test()
     Lexemes lexemes = {0};
     lexemes_init(&lexemes, &a);
     lexemes.count = 1;
-    lexemes.vals[0] = arena_malloc(&a, sizeof(V), char);
-    memcpy(lexemes.vals[0], V, sizeof(V) - 1);
-    lexemes.lens[0] = sizeof(V);
+    lexemes.strs[0].value = arena_malloc(&a, sizeof(V), char);
+    memcpy(lexemes.strs[0].value, V, sizeof(V) - 1);
+    lexemes.strs[0].length = sizeof(V);
     lexemes.ops[0] = OP_HOME_EXPANSION;
     #undef V
 
     expansion_home(&shell, &lexemes, 0, &a);
 
-    eassert(!memcmp(lexemes.vals[0], expected->value, expected->length - 1));
-    eassert(lexemes.lens[0] == expected->length);
+    eassert(!memcmp(lexemes.strs[0].value, expected->value, expected->length - 1));
+    eassert(lexemes.strs[0].length == expected->length);
     eassert(lexemes.ops[0] == OP_CONSTANT);
 
     ARENA_TEST_TEARDOWN;
@@ -76,12 +76,12 @@ void expansion_variable_path_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("$PATH", sizeof("$PATH"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("$PATH"), cmds, &shell, &a);
 
-    eassert(cmds->vals);
-    eassert(cmds->vals[0]);
-    eassert(!memcmp(cmds->vals[0], path, path_len - 1));
-    eassert(cmds->lens[0] == path_len);
+    eassert(cmds->strs);
+    eassert(cmds->strs[0].value);
+    eassert(!memcmp(cmds->strs[0].value, path, path_len - 1));
+    eassert(cmds->strs[0].length == path_len);
     eassert(cmds->ops[0] == OP_CONSTANT);
     eassert(cmds->pos == 1);
 
@@ -99,12 +99,12 @@ void expansion_variable_path_no_dollar_sign_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("PATH", sizeof("PATH"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("PATH"), cmds, &shell, &a);
 
-    eassert(cmds->vals);
-    eassert(cmds->vals[0]);
-    eassert(!memcmp(cmds->vals[0], path, path_len - 1));
-    eassert(cmds->lens[0] == path_len);
+    eassert(cmds->strs);
+    eassert(cmds->strs[0].value);
+    eassert(!memcmp(cmds->strs[0].value, path, path_len - 1));
+    eassert(cmds->strs[0].length == path_len);
     eassert(cmds->ops[0] = OP_CONSTANT);
     eassert(cmds->pos == 1);
 
@@ -121,10 +121,10 @@ void expansion_variable_home_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("$HOME", sizeof("$HOME"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("$HOME"), cmds, &shell, &a);
 
-    eassert(!memcmp(cmds->vals[0], home.value, home.length - 1));
-    cmds->lens[0] = home.length;
+    eassert(!memcmp(cmds->strs[0].value, home.value, home.length - 1));
+    cmds->strs[0].length = home.length;
     cmds->ops[0] = OP_CONSTANT;
     eassert(cmds->pos == 1);
 
@@ -141,10 +141,10 @@ void expansion_variable_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("$VAL", sizeof("$VAL"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("$VAL"), cmds, &shell, &a);
 
-    eassert(!memcmp(cmds->vals[0], "hello", sizeof("hello") - 1));
-    cmds->lens[0] = sizeof("hello");
+    eassert(!memcmp(cmds->strs[0].value, "hello", sizeof("hello") - 1));
+    cmds->strs[0].length = sizeof("hello");
     cmds->ops[0] = OP_CONSTANT;
     eassert(cmds->pos == 1);
 
@@ -161,10 +161,10 @@ void expansion_variable_no_dollar_sign_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("VAL", sizeof("VAL"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("VAL"), cmds, &shell, &a);
 
-    eassert(!memcmp(cmds->vals[0], "hello", sizeof("hello") - 1));
-    cmds->lens[0] = sizeof("hello");
+    eassert(!memcmp(cmds->strs[0].value, "hello", sizeof("hello") - 1));
+    cmds->strs[0].length = sizeof("hello");
     cmds->ops[0] = OP_CONSTANT;
     eassert(cmds->pos == 1);
 
@@ -182,10 +182,10 @@ void expansion_variable_with_spaces_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("$VAL", sizeof("$VAL"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("$VAL"), cmds, &shell, &a);
 
-    eassert(!memcmp(cmds->vals[0], v.value, v.length - 1));
-    cmds->lens[0] = v.length;
+    eassert(!memcmp(cmds->strs[0].value, v.value, v.length - 1));
+    cmds->strs[0].length = v.length;
     cmds->ops[0] = OP_CONSTANT;
     eassert(cmds->pos == 1);
 
@@ -203,10 +203,10 @@ void expansion_variable_number_test()
 
     Commands* cmds = commands_alloc(&a);
 
-    expansion_variable("$VAL", sizeof("$VAL"), cmds, &shell, &a);
+    expansion_variable(&Str_New_Literal("$VAL"), cmds, &shell, &a);
 
-    eassert(!memcmp(cmds->vals[0], v.value, v.length - 1));
-    cmds->lens[0] = v.length;
+    eassert(!memcmp(cmds->strs[0].value, v.value, v.length - 1));
+    cmds->strs[0].length = v.length;
     cmds->ops[0] = OP_CONSTANT;
     eassert(cmds->pos == 1);
 

--- a/tests/interpreter/lexer_tests.c
+++ b/tests/interpreter/lexer_tests.c
@@ -20,12 +20,12 @@ void lexer_lex_ls_test()
 
     eassert(lexemes.count == 1);
 
-    eassert(lexemes.vals[0]);
-    eassert(!memcmp(lexemes.vals[0], line, len));
+    eassert(lexemes.strs[0].value);
+    eassert(!memcmp(lexemes.strs[0].value, line, len));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == len);
+    eassert(lexemes.strs[0].length == len);
 
-    eassert(!lexemes.vals[1]);
+    eassert(!lexemes.strs[1].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -42,15 +42,15 @@ void lexer_lex_ls_dash_l_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "-l", 3));
+    eassert(!memcmp(lexemes.strs[1].value, "-l", 3));
     eassert(lexemes.ops[1] == OP_CONSTANT);
-    eassert(lexemes.lens[1] == 3);
+    eassert(lexemes.strs[1].length == 3);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -67,24 +67,24 @@ void lexer_lex_pipe_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(memcmp(lexemes.vals[0], "ls", 3) == 0);
+    eassert(memcmp(lexemes.strs[0].value, "ls", 3) == 0);
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(memcmp(lexemes.vals[1], "|", 2) == 0);
+    eassert(memcmp(lexemes.strs[1].value, "|", 2) == 0);
     eassert(lexemes.ops[1] == OP_PIPE);
-    eassert(lexemes.lens[1] == 2);
+    eassert(lexemes.strs[1].length == 2);
 
-    eassert(memcmp(lexemes.vals[2], "sort", 5) == 0);
+    eassert(memcmp(lexemes.strs[2].value, "sort", 5) == 0);
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 5);
+    eassert(lexemes.strs[2].length == 5);
 
-    eassert(!lexemes.vals[3]);
+    eassert(!lexemes.strs[3].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
 
-void lexer_lex_multiple_pipe_test()
+void lexer_lex_multiple_pipes_test()
 {
     SCRATCH_ARENA_TEST_SETUP;
 
@@ -96,27 +96,80 @@ void lexer_lex_multiple_pipe_test()
 
     eassert(lexemes.count == 5);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "|", 2));
+    eassert(!memcmp(lexemes.strs[1].value, "|", 2));
     eassert(lexemes.ops[1] == OP_PIPE);
-    eassert(lexemes.lens[1] == 2);
+    eassert(lexemes.strs[1].length == 2);
 
-    eassert(!memcmp(lexemes.vals[2], "sort", 5));
+    eassert(!memcmp(lexemes.strs[2].value, "sort", 5));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 5);
+    eassert(lexemes.strs[2].length == 5);
 
-    eassert(!memcmp(lexemes.vals[3], "|", 2));
+    eassert(!memcmp(lexemes.strs[3].value, "|", 2));
     eassert(lexemes.ops[3] == OP_PIPE);
-    eassert(lexemes.lens[3] == 2);
+    eassert(lexemes.strs[3].length == 2);
 
-    eassert(!memcmp(lexemes.vals[4], "table", 6));
+    eassert(!memcmp(lexemes.strs[4].value, "table", 6));
     eassert(lexemes.ops[4] == OP_CONSTANT);
-    eassert(lexemes.lens[4] == 6);
+    eassert(lexemes.strs[4].length == 6);
 
-    eassert(!lexemes.vals[5]);
+    eassert(!lexemes.strs[5].value);
+
+    SCRATCH_ARENA_TEST_TEARDOWN;
+}
+
+void lexer_lex_multiple_pipes_multiple_args_test()
+{
+    SCRATCH_ARENA_TEST_SETUP;
+
+    char* line = "ls | sort | head -1 | wc -c";
+    size_t len = strlen(line) + 1;
+
+    Lexemes lexemes = {0};
+    lexer_lex(line, len, &lexemes, &scratch_arena);
+
+    eassert(lexemes.count == 9);
+
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 2));
+    eassert(lexemes.ops[0] == OP_CONSTANT);
+    eassert(lexemes.strs[0].length == 3);
+
+    eassert(memcmp(lexemes.strs[1].value, "|", 2) == 0);
+    eassert(lexemes.ops[1] == OP_PIPE);
+    eassert(lexemes.strs[1].length == 2);
+
+    eassert(!memcmp(lexemes.strs[2].value, "sort", 4));
+    eassert(lexemes.ops[2] == OP_CONSTANT);
+    eassert(lexemes.strs[2].length == 5);
+
+    eassert(memcmp(lexemes.strs[3].value, "|", 2) == 0);
+    eassert(lexemes.ops[3] == OP_PIPE);
+    eassert(lexemes.strs[3].length == 2);
+
+    eassert(!memcmp(lexemes.strs[4].value, "head", 4));
+    eassert(lexemes.ops[4] == OP_CONSTANT);
+    eassert(lexemes.strs[4].length == 5);
+
+    eassert(!memcmp(lexemes.strs[5].value, "-1", 2));
+    eassert(lexemes.ops[5] == OP_CONSTANT);
+    eassert(lexemes.strs[5].length == 3);
+
+    eassert(memcmp(lexemes.strs[6].value, "|", 2) == 0);
+    eassert(lexemes.ops[6] == OP_PIPE);
+    eassert(lexemes.strs[6].length == 2);
+
+    eassert(!memcmp(lexemes.strs[7].value, "wc", 2));
+    eassert(lexemes.ops[7] == OP_CONSTANT);
+    eassert(lexemes.strs[7].length == 3);
+
+    eassert(!memcmp(lexemes.strs[8].value, "-c", 2));
+    eassert(lexemes.ops[8] == OP_CONSTANT);
+    eassert(lexemes.strs[8].length == 3);
+
+    eassert(!lexemes.strs[9].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -133,15 +186,15 @@ void lexer_lex_background_job_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "longrunningprogram", 19));
+    eassert(!memcmp(lexemes.strs[0].value, "longrunningprogram", 19));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 19);
+    eassert(lexemes.strs[0].length == 19);
 
-    eassert(!memcmp(lexemes.vals[1], "&", 2));
+    eassert(!memcmp(lexemes.strs[1].value, "&", 2));
     eassert(lexemes.ops[1] == OP_BACKGROUND_JOB);
-    eassert(lexemes.lens[1] == 2);
+    eassert(lexemes.strs[1].length == 2);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -158,19 +211,19 @@ void lexer_lex_output_redirection_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], ">", 2));
+    eassert(!memcmp(lexemes.strs[1].value, ">", 2));
     eassert(lexemes.ops[1] == OP_STDOUT_REDIRECTION);
-    eassert(lexemes.lens[1] == 2);
+    eassert(lexemes.strs[1].length == 2);
 
-    eassert(!memcmp(lexemes.vals[2], "text.txt", 9));
+    eassert(!memcmp(lexemes.strs[2].value, "text.txt", 9));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 9);
+    eassert(lexemes.strs[2].length == 9);
 
-    eassert(!lexemes.vals[3]);
+    eassert(!lexemes.strs[3].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -187,19 +240,19 @@ void lexer_lex_output_redirection_append_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], ">>", 3));
+    eassert(!memcmp(lexemes.strs[1].value, ">>", 3));
     eassert(lexemes.ops[1] == OP_STDOUT_REDIRECTION_APPEND);
-    eassert(lexemes.lens[1] == 3);
+    eassert(lexemes.strs[1].length == 3);
 
-    eassert(!memcmp(lexemes.vals[2], "text.txt", 9));
+    eassert(!memcmp(lexemes.strs[2].value, "text.txt", 9));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 9);
+    eassert(lexemes.strs[2].length == 9);
 
-    eassert(!lexemes.vals[3]);
+    eassert(!lexemes.strs[3].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -216,17 +269,17 @@ void lexer_lex_input_redirection_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(!memcmp(lexemes.vals[0], "t.txt", 6));
+    eassert(!memcmp(lexemes.strs[0].value, "t.txt", 6));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 6);
+    eassert(lexemes.strs[0].length == 6);
 
-    eassert(!memcmp(lexemes.vals[1], "<", 2));
+    eassert(!memcmp(lexemes.strs[1].value, "<", 2));
     eassert(lexemes.ops[1] == OP_STDIN_REDIRECTION);
-    eassert(lexemes.lens[1] == 2);
+    eassert(lexemes.strs[1].length == 2);
 
-    eassert(!memcmp(lexemes.vals[2], "sort", 5));
+    eassert(!memcmp(lexemes.strs[2].value, "sort", 5));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 5);
+    eassert(lexemes.strs[2].length == 5);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -243,19 +296,19 @@ void lexer_lex_stdout_and_stderr_redirection_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "&>", 3));
+    eassert(!memcmp(lexemes.strs[1].value, "&>", 3));
     eassert(lexemes.ops[1] == OP_STDOUT_AND_STDERR_REDIRECTION);
-    eassert(lexemes.lens[1] == 3);
+    eassert(lexemes.strs[1].length == 3);
 
-    eassert(!memcmp(lexemes.vals[2], "text.txt", 9));
+    eassert(!memcmp(lexemes.strs[2].value, "text.txt", 9));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 9);
+    eassert(lexemes.strs[2].length == 9);
 
-    eassert(!lexemes.vals[3]);
+    eassert(!lexemes.strs[3].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -272,19 +325,19 @@ void lexer_lex_stdout_and_stderr_redirection_append_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "&>>", 4));
+    eassert(!memcmp(lexemes.strs[1].value, "&>>", 4));
     eassert(lexemes.ops[1] == OP_STDOUT_AND_STDERR_REDIRECTION_APPEND);
-    eassert(lexemes.lens[1] == 4);
+    eassert(lexemes.strs[1].length == 4);
 
-    eassert(!memcmp(lexemes.vals[2], "text.txt", 9));
+    eassert(!memcmp(lexemes.strs[2].value, "text.txt", 9));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 9);
+    eassert(lexemes.strs[2].length == 9);
 
-    eassert(!lexemes.vals[3]);
+    eassert(!lexemes.strs[3].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -303,11 +356,11 @@ void lexer_lex_assignment_test()
 
     // quotes stripped by the lexer
     size_t stripped_len = sizeof("STR=Hello");
-    eassert(!memcmp(lexemes.vals[0], "STR=Hello", stripped_len));
+    eassert(!memcmp(lexemes.strs[0].value, "STR=Hello", stripped_len));
     eassert(lexemes.ops[0] == OP_ASSIGNMENT);
-    eassert(lexemes.lens[0] == stripped_len);
+    eassert(lexemes.strs[0].length == stripped_len);
 
-    eassert(!lexemes.vals[1]);
+    eassert(!lexemes.strs[1].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -325,11 +378,11 @@ void lexer_lex_assignment_spaces_test()
     eassert(lexemes.count == 1);
 
     // quotes stripped by the lexer
-    eassert(!memcmp(lexemes.vals[0], "STR=ls -a", len - 2));
+    eassert(!memcmp(lexemes.strs[0].value, "STR=ls -a", len - 2));
     eassert(lexemes.ops[0] == OP_ASSIGNMENT);
-    eassert(lexemes.lens[0] == len - 2);
+    eassert(lexemes.strs[0].length == len - 2);
 
-    eassert(!lexemes.vals[1]);
+    eassert(!lexemes.strs[1].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -347,11 +400,11 @@ void lexer_lex_assignment_spaces_multiple_test()
     eassert(lexemes.count == 1);
 
     // quotes stripped by the lexer
-    eassert(!memcmp(lexemes.vals[0], "STR=ls | sort", len - 2));
+    eassert(!memcmp(lexemes.strs[0].value, "STR=ls | sort", len - 2));
     eassert(lexemes.ops[0] == OP_ASSIGNMENT);
-    eassert(lexemes.lens[0] == len - 2);
+    eassert(lexemes.strs[0].length == len - 2);
 
-    eassert(!lexemes.vals[1])
+    eassert(!lexemes.strs[1].value)
 
         SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -368,15 +421,15 @@ void lexer_lex_variable_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "echo", 5));
+    eassert(!memcmp(lexemes.strs[0].value, "echo", 5));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] = 5);
+    eassert(lexemes.strs[0].length = 5);
 
-    eassert(!memcmp(lexemes.vals[1], "$STR", 5));
+    eassert(!memcmp(lexemes.strs[1].value, "$STR", 5));
     eassert(lexemes.ops[1] == OP_VARIABLE);
-    eassert(lexemes.lens[1] = 5);
+    eassert(lexemes.strs[1].length = 5);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -393,23 +446,23 @@ void lexer_lex_variable_and_test()
 
     eassert(lexemes.count == 4);
 
-    eassert(!memcmp(lexemes.vals[0], "STR=hello", sizeof("STR=hello")));
+    eassert(!memcmp(lexemes.strs[0].value, "STR=hello", sizeof("STR=hello")));
     eassert(lexemes.ops[0] == OP_ASSIGNMENT);
-    eassert(lexemes.lens[0] == sizeof("STR=hello"));
+    eassert(lexemes.strs[0].length == sizeof("STR=hello"));
 
-    eassert(!memcmp(lexemes.vals[1], "&&", 3));
+    eassert(!memcmp(lexemes.strs[1].value, "&&", 3));
     eassert(lexemes.ops[1] == OP_AND);
-    eassert(lexemes.lens[1] == 3);
+    eassert(lexemes.strs[1].length == 3);
 
-    eassert(!memcmp(lexemes.vals[2], "echo", 5));
+    eassert(!memcmp(lexemes.strs[2].value, "echo", 5));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] = 5);
+    eassert(lexemes.strs[2].length = 5);
 
-    eassert(!memcmp(lexemes.vals[3], "$STR", 5));
+    eassert(!memcmp(lexemes.strs[3].value, "$STR", 5));
     eassert(lexemes.ops[3] == OP_VARIABLE);
-    eassert(lexemes.lens[3] = 5);
+    eassert(lexemes.strs[3].length = 5);
 
-    eassert(!lexemes.vals[4]);
+    eassert(!lexemes.strs[4].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -426,19 +479,19 @@ void lexer_lex_variable_command_test()
 
     eassert(lexemes.count == 3);
 
-    eassert(!memcmp(lexemes.vals[0], "COMMAND=ls", sizeof("COMMAND=ls")));
+    eassert(!memcmp(lexemes.strs[0].value, "COMMAND=ls", sizeof("COMMAND=ls")));
     eassert(lexemes.ops[0] == OP_ASSIGNMENT);
-    eassert(lexemes.lens[0] == sizeof("COMMAND=ls"));
+    eassert(lexemes.strs[0].length == sizeof("COMMAND=ls"));
 
-    eassert(!memcmp(lexemes.vals[1], "&&", 3));
+    eassert(!memcmp(lexemes.strs[1].value, "&&", 3));
     eassert(lexemes.ops[1] == OP_AND);
-    eassert(lexemes.lens[1] == 3);
+    eassert(lexemes.strs[1].length == 3);
 
-    eassert(!memcmp(lexemes.vals[2], "$COMMAND", 8));
+    eassert(!memcmp(lexemes.strs[2].value, "$COMMAND", 8));
     eassert(lexemes.ops[2] == OP_VARIABLE);
-    eassert(lexemes.lens[2] = 8);
+    eassert(lexemes.strs[2].length = 8);
 
-    eassert(!lexemes.vals[3]);
+    eassert(!lexemes.strs[3].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -455,15 +508,15 @@ void lexer_lex_double_quotes_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "echo", 5));
+    eassert(!memcmp(lexemes.strs[0].value, "echo", 5));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 5);
+    eassert(lexemes.strs[0].length == 5);
 
-    eassert(!memcmp(lexemes.vals[1], "hello", 6));
+    eassert(!memcmp(lexemes.strs[1].value, "hello", 6));
     eassert(lexemes.ops[1] == OP_CONSTANT);
-    eassert(lexemes.lens[1] == 6);
+    eassert(lexemes.strs[1].length == 6);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -480,15 +533,15 @@ void lexer_lex_single_quotes_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "echo", 5));
+    eassert(!memcmp(lexemes.strs[0].value, "echo", 5));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 5);
+    eassert(lexemes.strs[0].length == 5);
 
-    eassert(!memcmp(lexemes.vals[1], "hello", 6));
+    eassert(!memcmp(lexemes.strs[1].value, "hello", 6));
     eassert(lexemes.ops[1] == OP_CONSTANT);
-    eassert(lexemes.lens[1] == 6);
+    eassert(lexemes.strs[1].length == 6);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -505,15 +558,15 @@ void lexer_lex_backtick_quotes_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "echo", 5));
+    eassert(!memcmp(lexemes.strs[0].value, "echo", 5));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 5);
+    eassert(lexemes.strs[0].length == 5);
 
-    eassert(!memcmp(lexemes.vals[1], "hello", 6));
+    eassert(!memcmp(lexemes.strs[1].value, "hello", 6));
     eassert(lexemes.ops[1] == OP_CONSTANT);
-    eassert(lexemes.lens[1] == 6);
+    eassert(lexemes.strs[1].length == 6);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -530,23 +583,23 @@ void lexer_lex_git_commit_test()
 
     eassert(lexemes.count == 4);
 
-    eassert(!memcmp(lexemes.vals[0], "git", 4));
+    eassert(!memcmp(lexemes.strs[0].value, "git", 4));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 4);
+    eassert(lexemes.strs[0].length == 4);
 
-    eassert(!memcmp(lexemes.vals[1], "commit", 7));
+    eassert(!memcmp(lexemes.strs[1].value, "commit", 7));
     eassert(lexemes.ops[1] == OP_CONSTANT);
-    eassert(lexemes.lens[1] == 7);
+    eassert(lexemes.strs[1].length == 7);
 
-    eassert(!memcmp(lexemes.vals[2], "-m", 3));
+    eassert(!memcmp(lexemes.strs[2].value, "-m", 3));
     eassert(lexemes.ops[2] == OP_CONSTANT);
-    eassert(lexemes.lens[2] == 3);
+    eassert(lexemes.strs[2].length == 3);
 
-    eassert(!memcmp(lexemes.vals[3], "this is a commit message", 25));
+    eassert(!memcmp(lexemes.strs[3].value, "this is a commit message", 25));
     eassert(lexemes.ops[3] == OP_CONSTANT);
-    eassert(lexemes.lens[3] == 25);
+    eassert(lexemes.strs[3].length == 25);
 
-    eassert(!lexemes.vals[4]);
+    eassert(!lexemes.strs[4].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -563,15 +616,15 @@ void lexer_lex_home_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "~", 2));
+    eassert(!memcmp(lexemes.strs[1].value, "~", 2));
     eassert(lexemes.ops[1] == OP_HOME_EXPANSION);
-    eassert(lexemes.lens[1] == 2);
+    eassert(lexemes.strs[1].length == 2);
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -588,15 +641,15 @@ void lexer_lex_home_at_start_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "~/snap", sizeof("~/snap") - 1));
+    eassert(!memcmp(lexemes.strs[1].value, "~/snap", sizeof("~/snap") - 1));
     eassert(lexemes.ops[1] == OP_HOME_EXPANSION);
-    eassert(lexemes.lens[1] == sizeof("~/snap"));
+    eassert(lexemes.strs[1].length == sizeof("~/snap"));
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -613,42 +666,42 @@ void lexer_lex_math_operators_test()
 
     eassert(lexemes.ops[0] == OP_MATH_EXPRESSION_START);
 
-    eassert(!memcmp(lexemes.vals[1], "1", 1));
+    eassert(!memcmp(lexemes.strs[1].value, "1", 1));
     eassert(lexemes.ops[1] == OP_CONSTANT);
 
     eassert(lexemes.ops[2] == OP_ADD);
 
-    eassert(!memcmp(lexemes.vals[3], "1", 1));
+    eassert(!memcmp(lexemes.strs[3].value, "1", 1));
     eassert(lexemes.ops[3] == OP_CONSTANT);
 
     eassert(lexemes.ops[4] == OP_SUBTRACT);
 
-    eassert(!memcmp(lexemes.vals[5], "1", 1));
+    eassert(!memcmp(lexemes.strs[5].value, "1", 1));
     eassert(lexemes.ops[5] == OP_CONSTANT);
 
     eassert(lexemes.ops[6] == OP_MULTIPLY);
 
-    eassert(!memcmp(lexemes.vals[7], "1", 1));
+    eassert(!memcmp(lexemes.strs[7].value, "1", 1));
     eassert(lexemes.ops[7] == OP_CONSTANT);
 
     eassert(lexemes.ops[8] == OP_DIVIDE);
 
-    eassert(!memcmp(lexemes.vals[9], "1", 1));
+    eassert(!memcmp(lexemes.strs[9].value, "1", 1));
     eassert(lexemes.ops[9] == OP_CONSTANT);
 
     eassert(lexemes.ops[10] == OP_MODULO);
 
-    eassert(!memcmp(lexemes.vals[11], "1", 1));
+    eassert(!memcmp(lexemes.strs[11].value, "1", 1));
     eassert(lexemes.ops[11] == OP_CONSTANT);
 
     eassert(lexemes.ops[12] == OP_EXPONENTIATION);
 
-    eassert(!memcmp(lexemes.vals[13], "1", 1));
+    eassert(!memcmp(lexemes.strs[13].value, "1", 1));
     eassert(lexemes.ops[13] == OP_CONSTANT);
 
     eassert(lexemes.ops[14] == OP_MATH_EXPRESSION_END);
 
-    eassert(!lexemes.vals[15]);
+    eassert(!lexemes.strs[15].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -665,15 +718,15 @@ void lexer_lex_glob_star_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "*.md", sizeof("*.md") - 1));
+    eassert(!memcmp(lexemes.strs[1].value, "*.md", sizeof("*.md") - 1));
     eassert(lexemes.ops[1] == OP_GLOB_EXPANSION);
-    eassert(lexemes.lens[1] == sizeof("*.md"));
+    eassert(lexemes.strs[1].length == sizeof("*.md"));
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -690,15 +743,15 @@ void lexer_lex_glob_question_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "ls", 3));
+    eassert(!memcmp(lexemes.strs[0].value, "ls", 3));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 3);
+    eassert(lexemes.strs[0].length == 3);
 
-    eassert(!memcmp(lexemes.vals[1], "?.md", sizeof("?.md") - 1));
+    eassert(!memcmp(lexemes.strs[1].value, "?.md", sizeof("?.md") - 1));
     eassert(lexemes.ops[1] == OP_GLOB_EXPANSION);
-    eassert(lexemes.lens[1] == sizeof("?.md"));
+    eassert(lexemes.strs[1].length == sizeof("?.md"));
 
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -716,9 +769,9 @@ void lexer_lex_glob_star_shouldnt_crash()
 
     eassert(lexemes.count == 18);
     for (size_t i = 0; i < lexemes.count; ++i) {
-        eassert(lexemes.vals[i][0] == '*');
+        eassert(lexemes.strs[i].value[0] == '*');
         eassert(lexemes.ops[0] == OP_GLOB_EXPANSION);
-        eassert(lexemes.lens[0] == 2);
+        eassert(lexemes.strs[0].length == 2);
     }
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -770,27 +823,27 @@ void lexer_lex_bool_test()
 
     eassert(lexemes.count == 5);
 
-    eassert(!memcmp(lexemes.vals[0], "false", 6));
+    eassert(!memcmp(lexemes.strs[0].value, "false", 6));
     eassert(lexemes.ops[0] == OP_FALSE);
-    eassert(lexemes.lens[0] == 6);
+    eassert(lexemes.strs[0].length == 6);
 
-    eassert(!memcmp(lexemes.vals[1], "&&", 3));
+    eassert(!memcmp(lexemes.strs[1].value, "&&", 3));
     eassert(lexemes.ops[1] == OP_AND);
-    eassert(lexemes.lens[1] == 3);
+    eassert(lexemes.strs[1].length == 3);
 
-    eassert(!memcmp(lexemes.vals[2], "true", 5));
+    eassert(!memcmp(lexemes.strs[2].value, "true", 5));
     eassert(lexemes.ops[2] == OP_TRUE);
-    eassert(lexemes.lens[2] == 5);
+    eassert(lexemes.strs[2].length == 5);
 
-    eassert(!memcmp(lexemes.vals[3], "||", 3));
+    eassert(!memcmp(lexemes.strs[3].value, "||", 3));
     eassert(lexemes.ops[3] == OP_OR);
-    eassert(lexemes.lens[3] == 3);
+    eassert(lexemes.strs[3].length == 3);
 
-    eassert(!memcmp(lexemes.vals[4], "false", 6));
+    eassert(!memcmp(lexemes.strs[4].value, "false", 6));
     eassert(lexemes.ops[4] == OP_FALSE);
-    eassert(lexemes.lens[4] == 6);
+    eassert(lexemes.strs[4].length == 6);
 
-    eassert(!lexemes.vals[5]);
+    eassert(!lexemes.strs[5].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -864,16 +917,16 @@ void lexer_lex_comment_test()
 
     eassert(lexemes.count == 2);
 
-    eassert(!memcmp(lexemes.vals[0], "echo", 5));
+    eassert(!memcmp(lexemes.strs[0].value, "echo", 5));
     eassert(lexemes.ops[0] == OP_CONSTANT);
-    eassert(lexemes.lens[0] == 5);
+    eassert(lexemes.strs[0].length == 5);
 
-    eassert(!memcmp(lexemes.vals[1], "hello", 6));
+    eassert(!memcmp(lexemes.strs[1].value, "hello", 6));
     eassert(lexemes.ops[1] == OP_CONSTANT);
-    eassert(lexemes.lens[1] == 6);
+    eassert(lexemes.strs[1].length == 6);
 
     // comment is stripped by the lexer
-    eassert(!lexemes.vals[2]);
+    eassert(!lexemes.strs[2].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -888,7 +941,8 @@ void lexer_tests()
     etest_run(lexer_lex_ls_test);
     etest_run(lexer_lex_ls_dash_l_test);
     etest_run(lexer_lex_pipe_test);
-    etest_run(lexer_lex_multiple_pipe_test);
+    etest_run(lexer_lex_multiple_pipes_test);
+    etest_run(lexer_lex_multiple_pipes_multiple_args_test);
     etest_run(lexer_lex_background_job_test);
     etest_run(lexer_lex_output_redirection_test);
     etest_run(lexer_lex_double_quotes_test);

--- a/tests/interpreter/parser_tests.c
+++ b/tests/interpreter/parser_tests.c
@@ -41,11 +41,11 @@ void parser_parse_ls_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], line, len));
-    eassert(statements.statements->commands->lens[0] == len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, line, len));
+    eassert(statements.statements->commands->strs[0].length == len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
 
     eassert(!statements.statements->commands->next);
 
@@ -69,15 +69,15 @@ void parser_parse_ls_dash_l_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], DASH_L, dashl_len - 1));
-    eassert(statements.statements->commands->lens[1] == dashl_len);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, DASH_L, dashl_len - 1));
+    eassert(statements.statements->commands->strs[1].length == dashl_len);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -102,27 +102,27 @@ void parser_parse_pipe_test()
 
     Commands* commands = statements.statements->commands;
     eassert(commands->count == 1);
-    eassert(!memcmp(commands->vals[0], LS, ls_len - 1));
-    eassert(commands->lens[0] == ls_len);
+    eassert(!memcmp(commands->strs[0].value, LS, ls_len - 1));
+    eassert(commands->strs[0].length == ls_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->current_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     commands = commands->next;
     eassert(commands->count == 1);
-    eassert(!memcmp(commands->vals[0], SORT, sort_len - 1));
-    eassert(commands->lens[0] == sort_len);
+    eassert(!memcmp(commands->strs[0].value, SORT, sort_len - 1));
+    eassert(commands->strs[0].length == sort_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
     eassert(!commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
 
-void parser_parse_multiple_pipe_test()
+void parser_parse_multiple_pipes_test()
 {
     SCRATCH_ARENA_TEST_SETUP;
 
@@ -141,38 +141,38 @@ void parser_parse_multiple_pipe_test()
 
     Commands* commands = statements.statements->commands;
     eassert(commands->count == 1);
-    eassert(!memcmp(commands->vals[0], LS, ls_len - 1));
-    eassert(commands->lens[0] == ls_len);
+    eassert(!memcmp(commands->strs[0].value, LS, ls_len - 1));
+    eassert(commands->strs[0].length == ls_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->current_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     commands = commands->next;
     eassert(commands->count == 1);
-    eassert(!memcmp(commands->vals[0], SORT, sort_len - 1));
-    eassert(commands->lens[0] == sort_len);
+    eassert(!memcmp(commands->strs[0].value, SORT, sort_len - 1));
+    eassert(commands->strs[0].length == sort_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->current_op == OP_PIPE);
     eassert(commands->prev_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     commands = commands->next;
     eassert(commands->count == 1);
-    eassert(!memcmp(commands->vals[0], "table", 5));
-    eassert(commands->lens[0] == 6);
+    eassert(!memcmp(commands->strs[0].value, "table", 5));
+    eassert(commands->strs[0].length == 6);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     eassert(!commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
 
-void parser_parse_multiple_pipe_multiple_args_test()
+void parser_parse_multiple_pipes_multiple_args_test()
 {
     SCRATCH_ARENA_TEST_SETUP;
 
@@ -184,6 +184,15 @@ void parser_parse_multiple_pipe_multiple_args_test()
     Statements statements = {0};
     int res = parser_parse(&lexemes, &statements, NULL, &scratch_arena);
 
+    Commands* c = statements.statements->commands;
+    while (c) {
+        for (size_t i = 0; i < c->count; ++i) {
+            printf("%s ", c->strs[i].value);
+        }
+        c = c->next;
+    }
+    puts("");
+
     eassert(!res);
     eassert(statements.count == 1);
     eassert(statements.statements->count == 1);
@@ -193,57 +202,57 @@ void parser_parse_multiple_pipe_multiple_args_test()
     Commands* commands = statements.statements->commands;
     eassert(commands->count == 1);
 
-    eassert(!memcmp(commands->vals[0], LS, ls_len - 1));
-    eassert(commands->lens[0] == ls_len);
+    eassert(!memcmp(commands->strs[0].value, LS, ls_len - 1));
+    eassert(commands->strs[0].length == ls_len);
     eassert(commands->ops[0] == OP_CONSTANT);
 
     eassert(commands->current_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     // Second command
     commands = commands->next;
     eassert(commands->count == 1);
 
-    eassert(!memcmp(commands->vals[0], SORT, sort_len - 1));
-    eassert(commands->lens[0] == sort_len);
+    eassert(!memcmp(commands->strs[0].value, SORT, sort_len - 1));
+    eassert(commands->strs[0].length == sort_len);
     eassert(commands->ops[0] == OP_CONSTANT);
 
     eassert(commands->current_op == OP_PIPE);
     eassert(commands->prev_op == OP_PIPE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     // Third command
     commands = commands->next;
     eassert(commands->count == 2);
 
-    eassert(!memcmp(commands->vals[0], "head", 4));
-    eassert(commands->lens[0] == 5);
+    eassert(!memcmp(commands->strs[0].value, "head", 4));
+    eassert(commands->strs[0].length == 5);
     eassert(commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(commands->vals[1], "-1", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "-1", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
 
     eassert(commands->prev_op == OP_PIPE);
 
-    eassert(!commands->vals[2]);
+    eassert(!commands->strs[2].value);
 
     // Fourth command
     commands = commands->next;
     eassert(commands->count == 2);
-    eassert(!memcmp(commands->vals[0], "wc", 2));
-    eassert(commands->lens[0] == 3);
+    eassert(!memcmp(commands->strs[0].value, "wc", 2));
+    eassert(commands->strs[0].length == 3);
     eassert(commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(commands->vals[1], "-c", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "-c", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
 
     eassert(commands->prev_op == OP_PIPE);
 
-    eassert(!commands->vals[2]);
+    eassert(!commands->strs[2].value);
 
     eassert(!commands->next);
 
@@ -267,11 +276,11 @@ void parser_parse_background_job_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], JOB, job_len - 1));
-    eassert(statements.statements->commands->lens[0] == job_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, JOB, job_len - 1));
+    eassert(statements.statements->commands->strs[0].length == job_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.is_bg_job);
@@ -296,11 +305,11 @@ void parser_parse_output_redirection_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_OUT);
@@ -327,11 +336,11 @@ void parser_parse_output_redirection_append_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_OUT_APPEND);
@@ -358,11 +367,11 @@ void parser_parse_input_redirection_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], SORT, sort_len - 1));
-    eassert(statements.statements->commands->lens[0] == sort_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, SORT, sort_len - 1));
+    eassert(statements.statements->commands->strs[0].length == sort_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_IN);
@@ -389,11 +398,11 @@ void parser_parse_input_redirection_append_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], SORT, sort_len - 1));
-    eassert(statements.statements->commands->lens[0] == sort_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, SORT, sort_len - 1));
+    eassert(statements.statements->commands->strs[0].length == sort_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_IN_APPEND);
@@ -420,11 +429,11 @@ void parser_parse_stderr_redirection_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_ERR);
@@ -451,11 +460,11 @@ void parser_parse_stderr_redirection_append_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_ERR_APPEND);
@@ -482,11 +491,11 @@ void parser_parse_stdout_and_stderr_redirection_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_OUT_ERR);
@@ -513,11 +522,11 @@ void parser_parse_stdout_and_stderr_redirection_append_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 1);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[1]);
+    eassert(!statements.statements->commands->strs[1].value);
     eassert(!statements.statements->commands->next);
 
     eassert(statements.redirect_type == RT_OUT_ERR_APPEND);
@@ -544,23 +553,23 @@ void parser_parse_git_commit_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 4);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], "git", 3));
-    eassert(statements.statements->commands->lens[0] == 4);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, "git", 3));
+    eassert(statements.statements->commands->strs[0].length == 4);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "commit", 6));
-    eassert(statements.statements->commands->lens[1] == 7);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "commit", 6));
+    eassert(statements.statements->commands->strs[1].length == 7);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[2], "-m", 2));
-    eassert(statements.statements->commands->lens[2] == 3);
+    eassert(!memcmp(statements.statements->commands->strs[2].value, "-m", 2));
+    eassert(statements.statements->commands->strs[2].length == 3);
     eassert(statements.statements->commands->ops[2] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[3], "this is a commit message", 24));
-    eassert(statements.statements->commands->lens[3] == 25);
+    eassert(!memcmp(statements.statements->commands->strs[3].value, "this is a commit message", 24));
+    eassert(statements.statements->commands->strs[3].length == 25);
     eassert(statements.statements->commands->ops[3] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[4]);
+    eassert(!statements.statements->commands->strs[4].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -651,15 +660,15 @@ void parser_parse_variable_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], ECHO, echo_len - 1));
-    eassert(statements.statements->commands->lens[0] == echo_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(statements.statements->commands->strs[0].length == echo_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "hello", 5));
-    eassert(statements.statements->commands->lens[1] == 6);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "hello", 5));
+    eassert(statements.statements->commands->strs[1].length == 6);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     ARENA_TEST_TEARDOWN;
@@ -687,15 +696,15 @@ void parser_parse_variable_expansion_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], ECHO, echo_len - 1));
-    eassert(statements.statements->commands->lens[0] == echo_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(statements.statements->commands->strs[0].length == echo_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "ls | sort", 9));
-    eassert(statements.statements->commands->lens[1] == 10);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "ls | sort", 9));
+    eassert(statements.statements->commands->strs[1].length == 10);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -720,15 +729,15 @@ void parser_parse_variable_and_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], ECHO, echo_len - 1));
-    eassert(statements.statements->commands->lens[0] == echo_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(statements.statements->commands->strs[0].length == echo_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "hello", 5));
-    eassert(statements.statements->commands->lens[1] == 6);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "hello", 5));
+    eassert(statements.statements->commands->strs[1].length == 6);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -755,11 +764,11 @@ void parser_parse_variable_command_test()
     eassert(statements.statements->commands->count == 1);
 
     Commands* cmds = statements.statements->commands;
-    eassert(!memcmp(cmds->vals[0], LS, ls_len - 1));
-    eassert(cmds->lens[0] == ls_len);
+    eassert(!memcmp(cmds->strs[0].value, LS, ls_len - 1));
+    eassert(cmds->strs[0].length == ls_len);
     eassert(cmds->ops[0] == OP_CONSTANT);
 
-    eassert(!cmds->vals[1]);
+    eassert(!cmds->strs[1].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -784,17 +793,17 @@ void parser_parse_home_test()
     eassert(statements.statements->commands->count == 2);
 
     // first command
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
     // second command
     Str home = Str_Get(getenv(NCSH_HOME_VAL));
-    eassert(!memcmp(statements.statements->commands->vals[1], home.value, home.length - 1));
-    eassert(statements.statements->commands->lens[1] == home.length);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, home.value, home.length - 1));
+    eassert(statements.statements->commands->strs[1].length == home.length);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -820,25 +829,25 @@ void parser_parse_home_at_start_test()
     eassert(statements.statements->commands->count == 2);
 
     // first command
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
     // construct home expanded value from '~/snap'
 
     Str home = Str_Get(getenv(NCSH_HOME_VAL));
-    char* val = arena_malloc(&scratch_arena, statements.statements->commands->lens[1] + home.length - 1, char);
+    char* val = arena_malloc(&scratch_arena, statements.statements->commands->strs[1].length + home.length - 1, char);
     memcpy(val, home.value, home.length - 1);
     memcpy(val + home.length - 1, "/snap", 5);
     // eassert(!memcmp(val, "/home/alex/snap", 15)); // just make sure constructing home expanded value correctly
     size_t val_len = strlen(val) + 1;
 
     // second command
-    eassert(!memcmp(statements.statements->commands->vals[1], val, val_len - 1));
-    eassert(statements.statements->commands->lens[1] == val_len);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, val, val_len - 1));
+    eassert(statements.statements->commands->strs[1].length == val_len);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -878,23 +887,23 @@ void parser_parse_glob_star_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 4);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "COMPILE.md", 10));
-    eassert(statements.statements->commands->lens[1] == 11);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "COMPILE.md", 10));
+    eassert(statements.statements->commands->strs[1].length == 11);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[2], "NOTES.md", 8));
-    eassert(statements.statements->commands->lens[2] == 9);
+    eassert(!memcmp(statements.statements->commands->strs[2].value, "NOTES.md", 8));
+    eassert(statements.statements->commands->strs[2].length == 9);
     eassert(statements.statements->commands->ops[2] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[3], "README.md", 9));
-    eassert(statements.statements->commands->lens[3] == 10);
+    eassert(!memcmp(statements.statements->commands->strs[3].value, "README.md", 9));
+    eassert(statements.statements->commands->strs[3].length == 10);
     eassert(statements.statements->commands->ops[3] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[4]);
+    eassert(!statements.statements->commands->strs[4].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -917,15 +926,15 @@ void parser_parse_glob_question_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "NOTES.md", 8));
-    eassert(statements.statements->commands->lens[1] == 9);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "NOTES.md", 8));
+    eassert(statements.statements->commands->strs[1].length == 9);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -948,15 +957,15 @@ void parser_parse_glob_question_midcommand_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], LS, ls_len - 1));
-    eassert(statements.statements->commands->lens[0] == ls_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, LS, ls_len - 1));
+    eassert(statements.statements->commands->strs[0].length == ls_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "NOTES.md", 8));
-    eassert(statements.statements->commands->lens[1] == 9);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "NOTES.md", 8));
+    eassert(statements.statements->commands->strs[1].length == 9);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -1042,15 +1051,15 @@ void parser_parse_comment_test()
     eassert(statements.statements->count == 1);
     eassert(statements.statements->commands->count == 2);
 
-    eassert(!memcmp(statements.statements->commands->vals[0], ECHO, echo_len - 1));
-    eassert(statements.statements->commands->lens[0] == echo_len);
+    eassert(!memcmp(statements.statements->commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(statements.statements->commands->strs[0].length == echo_len);
     eassert(statements.statements->commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(statements.statements->commands->vals[1], "hello", 5));
-    eassert(statements.statements->commands->lens[1] == 6);
+    eassert(!memcmp(statements.statements->commands->strs[1].value, "hello", 5));
+    eassert(statements.statements->commands->strs[1].length == 6);
     eassert(statements.statements->commands->ops[1] == OP_CONSTANT);
 
-    eassert(!statements.statements->commands->vals[2]);
+    eassert(!statements.statements->commands->strs[2].value);
     eassert(!statements.statements->commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -1076,36 +1085,36 @@ void parser_parse_bool_test()
     Commands* commands = statements.statements->commands;
     eassert(commands->count == 1);
 
-    eassert(!memcmp(commands->vals[0], "false", 5));
-    eassert(commands->lens[0] == 6);
+    eassert(!memcmp(commands->strs[0].value, "false", 5));
+    eassert(commands->strs[0].length == 6);
     eassert(commands->ops[0] == OP_FALSE);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     // second command
     commands = commands->next;
     eassert(commands->count == 1);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], "true", 4));
-    eassert(commands->lens[0] == 5);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, "true", 4));
+    eassert(commands->strs[0].length == 5);
     eassert(commands->ops[0] == OP_TRUE);
     eassert(commands->prev_op == OP_AND);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     // third command
     commands = commands->next;
     eassert(commands->count == 1);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], "false", 5));
-    eassert(commands->lens[0] == 6);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, "false", 5));
+    eassert(commands->strs[0].length == 6);
     eassert(commands->ops[0] == OP_FALSE);
     eassert(commands->prev_op == OP_OR);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
     eassert(!commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -1133,20 +1142,20 @@ void parser_parse_if_test()
     eassert(statements.statements[0].type == LT_IF_CONDITIONS);
     eassert(commands->count == 3);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "1", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "1", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // second statement, if statements
@@ -1155,19 +1164,19 @@ void parser_parse_if_test()
     eassert(statements.statements[1].type == LT_IF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hi", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "hi", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
     // eassert(!commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -1198,22 +1207,22 @@ void parser_parse_if_variable_test()
     Commands* commands = statements.statements[0].commands;
     eassert(statements.statements[0].count == 1);
     eassert(statements.statements[0].type == LT_IF_CONDITIONS);
-    eassert(commands->count == 3);
+    eassert(commands->count == 2);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "1", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "1", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // second statement, if statements
@@ -1222,19 +1231,19 @@ void parser_parse_if_variable_test()
     eassert(statements.statements[1].type == LT_IF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hi", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "hi", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
     // eassert(!commands->next);
 
     ARENA_TEST_TEARDOWN;
@@ -1263,19 +1272,19 @@ void parser_parse_if_multiple_conditions_test()
     eassert(statements.statements[0].type == LT_IF_CONDITIONS);
     eassert(commands->count == 1);
 
-    eassert(!memcmp(commands->vals[0], "true", 4));
-    eassert(commands->lens[0] == 5);
+    eassert(!memcmp(commands->strs[0].value, "true", 4));
+    eassert(commands->strs[0].length == 5);
     eassert(commands->ops[0] == OP_TRUE);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
 
     commands = commands->next;
-    eassert(!memcmp(commands->vals[0], "true", 4));
-    eassert(commands->lens[0] == 5);
+    eassert(!memcmp(commands->strs[0].value, "true", 4));
+    eassert(commands->strs[0].length == 5);
     eassert(commands->ops[0] == OP_TRUE);
     eassert(commands->prev_op == OP_AND);
 
-    eassert(!commands->vals[1]);
+    eassert(!commands->strs[1].value);
     eassert(!commands->next);
 
     // second statement, if statements
@@ -1284,19 +1293,19 @@ void parser_parse_if_multiple_conditions_test()
     eassert(statements.statements[1].type == LT_IF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hi", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "hi", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
     // eassert(!commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -1324,21 +1333,21 @@ void parser_parse_if_else_test()
     eassert(statements.statements[0].type == LT_IF_CONDITIONS);
     eassert(commands->count == 3);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "1", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "1", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // second statement, if statements
@@ -1347,18 +1356,18 @@ void parser_parse_if_else_test()
     eassert(statements.statements[1].type == LT_IF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hi", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "hi", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
+    eassert(!commands->strs[2].value);
     // eassert(!commands->next);
 
     // third statement, else statements
@@ -1367,20 +1376,20 @@ void parser_parse_if_else_test()
     eassert(statements.statements[2].type == LT_ELSE);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hello", 5));
-    eassert(commands->lens[1] == 6);
+    eassert(!memcmp(commands->strs[1].value, "hello", 5));
+    eassert(commands->strs[1].length == 6);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
-    // TODO: fix this so commands->next is null and don't need to check vals[0]
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
+    // TODO: fix this so commands->next is null and don't need to check strs[0].value
     // eassert(!commands->next);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
@@ -1408,22 +1417,22 @@ void parser_parse_if_elif_else_test()
     eassert(statements.statements[0].type == LT_IF_CONDITIONS);
     eassert(commands->count == 3);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
     eassert(commands->current_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "2", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "2", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // second statement
@@ -1432,19 +1441,19 @@ void parser_parse_if_elif_else_test()
     eassert(statements.statements[1].type == LT_IF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hi", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "hi", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
 
     // third statement
     commands = statements.statements[2].commands;
@@ -1452,22 +1461,22 @@ void parser_parse_if_elif_else_test()
     eassert(statements.statements[2].type == LT_ELIF_CONDTIONS);
     eassert(commands->count == 3);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
     eassert(commands->current_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "1", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "1", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // fourth statement
@@ -1476,19 +1485,19 @@ void parser_parse_if_elif_else_test()
     eassert(statements.statements[3].type == LT_ELIF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hey", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "hey", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
 
     // fifth statement
     commands = statements.statements[4].commands;
@@ -1496,19 +1505,19 @@ void parser_parse_if_elif_else_test()
     eassert(statements.statements[4].type == LT_ELSE);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hello", 5));
-    eassert(commands->lens[1] == 6);
+    eassert(!memcmp(commands->strs[1].value, "hello", 5));
+    eassert(commands->strs[1].length == 6);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
@@ -1535,22 +1544,22 @@ void parser_parse_if_elif_test()
     eassert(statements.statements[0].type == LT_IF_CONDITIONS);
     eassert(commands->count == 3);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
     eassert(commands->current_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "2", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "2", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // second statement
@@ -1559,19 +1568,19 @@ void parser_parse_if_elif_test()
     eassert(statements.statements[1].type == LT_IF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hi", 2));
-    eassert(commands->lens[1] == 3);
+    eassert(!memcmp(commands->strs[1].value, "hi", 2));
+    eassert(commands->strs[1].length == 3);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
 
     // third statement
     commands = statements.statements[2].commands;
@@ -1579,22 +1588,22 @@ void parser_parse_if_elif_test()
     eassert(statements.statements[2].type == LT_ELIF_CONDTIONS);
     eassert(commands->count == 3);
 
-    eassert(!memcmp(commands->vals[0], "1", 1));
-    eassert(commands->lens[0] == 2);
+    eassert(!memcmp(commands->strs[0].value, "1", 1));
+    eassert(commands->strs[0].length == 2);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[1], "-eq", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "-eq", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_EQUALS);
     eassert(commands->current_op == OP_EQUALS);
 
-    eassert(!memcmp(commands->vals[2], "1", 1));
-    eassert(commands->lens[2] == 2);
+    eassert(!memcmp(commands->strs[2].value, "1", 1));
+    eassert(commands->strs[2].length == 2);
     eassert(commands->ops[2] == OP_CONSTANT);
     eassert(commands->prev_op == OP_EQUALS);
 
-    eassert(!commands->vals[3]);
+    eassert(!commands->strs[3].value);
     eassert(!commands->next);
 
     // fourth statement
@@ -1603,33 +1612,34 @@ void parser_parse_if_elif_test()
     eassert(statements.statements[3].type == LT_ELIF);
     eassert(commands->count == 2);
 
-    eassert(commands->vals[0]);
-    eassert(!memcmp(commands->vals[0], ECHO, echo_len - 1));
-    eassert(commands->lens[0] == echo_len);
+    eassert(commands->strs[0].value);
+    eassert(!memcmp(commands->strs[0].value, ECHO, echo_len - 1));
+    eassert(commands->strs[0].length == echo_len);
     eassert(commands->ops[0] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!memcmp(commands->vals[1], "hey", 3));
-    eassert(commands->lens[1] == 4);
+    eassert(!memcmp(commands->strs[1].value, "hey", 3));
+    eassert(commands->strs[1].length == 4);
     eassert(commands->ops[1] == OP_CONSTANT);
     eassert(commands->prev_op == OP_NONE);
 
-    eassert(!commands->vals[2]);
-    eassert(!commands->next->vals[0]);
+    eassert(!commands->strs[2].value);
+    eassert(!commands->next->strs[0].value);
 
     SCRATCH_ARENA_TEST_TEARDOWN;
 }
 
 void parser_tests()
 {
+    etest_init(true);
     etest_start();
 
     etest_run(parser_parse_ls_test);
     etest_run(parser_parse_ls_dash_l_test);
 
     etest_run(parser_parse_pipe_test);
-    etest_run(parser_parse_multiple_pipe_test);
-    etest_run(parser_parse_multiple_pipe_multiple_args_test);
+    etest_run(parser_parse_multiple_pipes_test);
+    etest_run(parser_parse_multiple_pipes_multiple_args_test);
 
     etest_run(parser_parse_background_job_test);
 
@@ -1670,7 +1680,7 @@ void parser_tests()
     etest_run(parser_parse_bool_test);
 
     etest_run(parser_parse_if_test);
-    // etest_run(parser_parse_if_variable_test);
+    etest_run(parser_parse_if_variable_test);
     etest_run(parser_parse_if_multiple_conditions_test);
     etest_run(parser_parse_if_else_test);
     etest_run(parser_parse_if_elif_else_test);

--- a/tests/interpreter/vm_next_tests.c
+++ b/tests/interpreter/vm_next_tests.c
@@ -42,10 +42,10 @@ void vm_next_simple_test()
     eassert(stmts.pos == 1);
     eassert(vm.state == VS_NORMAL);
     eassert(vm.op_current == OP_NONE);
-    eassert(!memcmp(vm.buffer[0], "ls", 2));
-    eassert(vm.buffer_lens[0] == 3);
+    eassert(!memcmp(vm.strs[0].value, "ls", 2));
+    eassert(vm.strs[0].length == 3);
 
-    eassert(!vm.buffer[1]);
+    eassert(!vm.strs[1].value);
     eassert(!cmds);
     eassert(vm.end);
 
@@ -78,10 +78,10 @@ void vm_next_bool_test()
     eassert(stmts.pos == 1);
     eassert(vm.state == VS_NORMAL);
     eassert(vm.op_current == OP_NONE);
-    eassert(!memcmp(vm.buffer[0], "ls", 2));
-    eassert(vm.buffer_lens[0] == 3);
+    eassert(!memcmp(vm.strs[0].value, "ls", 2));
+    eassert(vm.strs[0].length == 3);
 
-    eassert(!vm.buffer[1]);
+    eassert(!vm.strs[1].value);
     eassert(!cmds);
     eassert(vm.end);
 
@@ -114,10 +114,10 @@ void vm_next_if_test()
     eassert(stmts.pos == 1);
     eassert(vm.state == VS_IN_CONDITIONS);
     eassert(vm.op_current == OP_EQUALS);
-    eassert(!memcmp(vm.buffer[0], "1", 1));
-    eassert(!memcmp(vm.buffer[1], "-eq", 1));
-    eassert(!memcmp(vm.buffer[2], "1", 1));
-    eassert(!vm.buffer[3]);
+    eassert(!memcmp(vm.strs[0].value, "1", 1));
+    eassert(!memcmp(vm.strs[1].value, "-eq", 1));
+    eassert(!memcmp(vm.strs[2].value, "1", 1));
+    eassert(!vm.strs[3].value);
 
     vm.state = EXIT_SUCCESS;
 
@@ -126,9 +126,9 @@ void vm_next_if_test()
 
     eassert(stmts.pos == 2);
     eassert(vm.state == VS_IN_IF_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hi", 2));
-    eassert(!vm.buffer[2]);
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hi", 2));
+    eassert(!vm.strs[2].value);
 
     eassert(vm.end);
     eassert(!cmds);
@@ -163,8 +163,8 @@ void vm_next_if_multiple_conditions_true_and_test()
     eassert(cmds);
     eassert(stmts.pos == 0);
     eassert(vm.state == VS_IN_CONDITIONS);
-    eassert(!memcmp(vm.buffer[0], "true", 4));
-    eassert(!vm.buffer[1]);
+    eassert(!memcmp(vm.strs[0].value, "true", 4));
+    eassert(!vm.strs[1].value);
 
     // assume first condition succeeds
     vm.state = EXIT_SUCCESS;
@@ -177,17 +177,17 @@ void vm_next_if_multiple_conditions_true_and_test()
     eassert(vm.state == VS_IN_CONDITIONS);
 
     eassert(vm.op_current == OP_AND);
-    eassert(!memcmp(vm.buffer[0], "true", 4));
+    eassert(!memcmp(vm.strs[0].value, "true", 4));
 
-    eassert(!vm.buffer[1]);
+    eassert(!vm.strs[1].value);
 
     // if statements
     cmds = vm_next(&stmts, cmds, &vm);
 
     eassert(stmts.pos == 2);
     eassert(vm.state == VS_IN_IF_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hi", 2));
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hi", 2));
 
     eassert(vm.end);
     eassert(!cmds);
@@ -223,9 +223,9 @@ void vm_next_if_multiple_conditions_false_and_test()
     eassert(stmts.pos == 0);
 
     eassert(vm.state == VS_IN_CONDITIONS);
-    eassert(!memcmp(vm.buffer[0], "false", 4));
+    eassert(!memcmp(vm.strs[0].value, "false", 4));
 
-    eassert(!vm.buffer[1]);
+    eassert(!vm.strs[1].value);
 
     // VM will short ciruit the and and stop evaluation
 
@@ -259,8 +259,8 @@ void vm_next_if_multiple_conditions_true_or_test()
     eassert(cmds);
     eassert(stmts.pos == 0);
     eassert(vm.state == VS_IN_CONDITIONS);
-    eassert(!memcmp(vm.buffer[0], "true", 4));
-    eassert(!vm.buffer[1]);
+    eassert(!memcmp(vm.strs[0].value, "true", 4));
+    eassert(!vm.strs[1].value);
 
     // assume first condition succeeds
     vm.state = EXIT_SUCCESS;
@@ -273,17 +273,17 @@ void vm_next_if_multiple_conditions_true_or_test()
     eassert(vm.state == VS_IN_CONDITIONS);
 
     eassert(vm.op_current == OP_OR);
-    eassert(!memcmp(vm.buffer[0], "true", 4));
+    eassert(!memcmp(vm.strs[0].value, "true", 4));
 
-    eassert(!vm.buffer[1]);
+    eassert(!vm.strs[1].value);
 
     // if statements
     cmds = vm_next(&stmts, cmds, &vm);
 
     eassert(stmts.pos == 2);
     eassert(vm.state == VS_IN_IF_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hi", 2));
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hi", 2));
 
     eassert(vm.end);
     eassert(!cmds);
@@ -318,12 +318,12 @@ void vm_next_if_else_true_test()
     eassert(stmts.pos == 1);
     eassert(vm.state == VS_IN_CONDITIONS);
     eassert(vm.op_current == OP_EQUALS);
-    eassert(!memcmp(vm.buffer[0], "1", 1));
-    eassert(vm.buffer_lens[0] == 2);
-    eassert(!memcmp(vm.buffer[1], "-eq", 1));
-    eassert(vm.buffer_lens[1] == 4);
-    eassert(!memcmp(vm.buffer[2], "1", 1));
-    eassert(vm.buffer_lens[2] == 2);
+    eassert(!memcmp(vm.strs[0].value, "1", 1));
+    eassert(vm.strs[0].length == 2);
+    eassert(!memcmp(vm.strs[1].value, "-eq", 1));
+    eassert(vm.strs[1].length == 4);
+    eassert(!memcmp(vm.strs[2].value, "1", 1));
+    eassert(vm.strs[2].length == 2);
 
     // simulate vm status (condition result)
     vm.status = EXIT_SUCCESS;
@@ -333,8 +333,8 @@ void vm_next_if_else_true_test()
 
     eassert(stmts.pos == 2);
     eassert(vm.state == VS_IN_IF_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hi", 2));
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hi", 2));
 
     eassert(vm.end);
     eassert(!cmds);
@@ -368,10 +368,10 @@ void vm_next_if_else_false_test()
 
     eassert(vm.state == VS_IN_CONDITIONS);
     eassert(vm.op_current == OP_EQUALS);
-    eassert(!memcmp(vm.buffer[0], "1", 1));
-    eassert(!memcmp(vm.buffer[1], "-eq", 1));
-    eassert(!memcmp(vm.buffer[2], "2", 1));
-    eassert(!vm.buffer[3]);
+    eassert(!memcmp(vm.strs[0].value, "1", 1));
+    eassert(!memcmp(vm.strs[1].value, "-eq", 1));
+    eassert(!memcmp(vm.strs[2].value, "2", 1));
+    eassert(!vm.strs[3].value);
 
     // simulate VM status (condition result)
     vm.status = EXIT_FAILURE;
@@ -380,10 +380,10 @@ void vm_next_if_else_false_test()
     cmds = vm_next(&stmts, cmds, &vm);
 
     eassert(vm.state == VS_IN_ELSE_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hello", 5));
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hello", 5));
 
-    eassert(!vm.buffer[2]);
+    eassert(!vm.strs[2].value);
     eassert(!cmds);
     eassert(vm.end);
 
@@ -417,12 +417,12 @@ void vm_next_if_elif_else_if_true_test()
     eassert(stmts.pos == 1);
     eassert(vm.state == VS_IN_CONDITIONS);
     eassert(vm.op_current == OP_EQUALS);
-    eassert(!memcmp(vm.buffer[0], "1", 1));
-    eassert(vm.buffer_lens[0] == 2);
-    eassert(!memcmp(vm.buffer[1], "-eq", 1));
-    eassert(vm.buffer_lens[1] == 4);
-    eassert(!memcmp(vm.buffer[2], "1", 1));
-    eassert(vm.buffer_lens[2] == 2);
+    eassert(!memcmp(vm.strs[0].value, "1", 1));
+    eassert(vm.strs[0].length == 2);
+    eassert(!memcmp(vm.strs[1].value, "-eq", 1));
+    eassert(vm.strs[1].length == 4);
+    eassert(!memcmp(vm.strs[2].value, "1", 1));
+    eassert(vm.strs[2].length == 2);
 
     // simulate vm status (condition result)
     vm.status = EXIT_SUCCESS;
@@ -432,8 +432,8 @@ void vm_next_if_elif_else_if_true_test()
 
     eassert(stmts.pos == 2);
     eassert(vm.state == VS_IN_IF_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hi", 2));
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hi", 2));
 
     eassert(vm.end);
     eassert(!cmds);
@@ -466,12 +466,12 @@ void vm_next_if_elif_else_elif_true_test()
     eassert(stmts.pos == 1);
     eassert(vm.state == VS_IN_CONDITIONS);
     eassert(vm.op_current == OP_EQUALS);
-    eassert(!memcmp(vm.buffer[0], "2", 1));
-    eassert(vm.buffer_lens[0] == 2);
-    eassert(!memcmp(vm.buffer[1], "-eq", 1));
-    eassert(vm.buffer_lens[1] == 4);
-    eassert(!memcmp(vm.buffer[2], "1", 1));
-    eassert(vm.buffer_lens[2] == 2);
+    eassert(!memcmp(vm.strs[0].value, "2", 1));
+    eassert(vm.strs[0].length == 2);
+    eassert(!memcmp(vm.strs[1].value, "-eq", 1));
+    eassert(vm.strs[1].length == 4);
+    eassert(!memcmp(vm.strs[2].value, "1", 1));
+    eassert(vm.strs[2].length == 2);
 
     // simulate vm status (condition result)
     vm.status = EXIT_FAILURE;
@@ -482,12 +482,12 @@ void vm_next_if_elif_else_elif_true_test()
     eassert(stmts.pos == 3);
     eassert(vm.state == VS_IN_CONDITIONS);
     eassert(vm.op_current == OP_EQUALS);
-    eassert(!memcmp(vm.buffer[0], "1", 1));
-    eassert(vm.buffer_lens[0] == 2);
-    eassert(!memcmp(vm.buffer[1], "-eq", 1));
-    eassert(vm.buffer_lens[1] == 4);
-    eassert(!memcmp(vm.buffer[2], "1", 1));
-    eassert(vm.buffer_lens[2] == 2);
+    eassert(!memcmp(vm.strs[0].value, "1", 1));
+    eassert(vm.strs[0].length == 2);
+    eassert(!memcmp(vm.strs[1].value, "-eq", 1));
+    eassert(vm.strs[1].length == 4);
+    eassert(!memcmp(vm.strs[2].value, "1", 1));
+    eassert(vm.strs[2].length == 2);
 
     // simulate vm status (condition result)
     vm.status = EXIT_SUCCESS;
@@ -499,8 +499,8 @@ void vm_next_if_elif_else_elif_true_test()
     printf("%zu\n", stmts.pos);
     eassert(stmts.pos == 4);
     eassert(vm.state == VS_IN_ELIF_STATEMENTS);
-    eassert(!memcmp(vm.buffer[0], "echo", 4));
-    eassert(!memcmp(vm.buffer[1], "hey", 2));
+    eassert(!memcmp(vm.strs[0].value, "echo", 4));
+    eassert(!memcmp(vm.strs[1].value, "hey", 2));
 
     eassert(vm.end);
     eassert(!cmds);

--- a/tests/lib/shell_test_helper.h
+++ b/tests/lib/shell_test_helper.h
@@ -5,6 +5,6 @@
 static inline void shell_init(Shell* restrict shell, Arena* scratch, char** envp)
 {
     shell->arena = *scratch;
-    shell->scratch_arena = *scratch;
+    shell->scratch = *scratch;
     env_new(shell, envp, &shell->arena);
 }

--- a/tests/z/z_tests.c
+++ b/tests/z/z_tests.c
@@ -16,10 +16,10 @@ static Str config_location = {.length = 0, .value = NULL};
 
 double z_score(z_Directory* restrict directory, int fzf_score, time_t now);
 
-z_Directory* z_match_find(char* restrict target, size_t target_length, char* restrict cwd, size_t cwd_length,
+z_Directory* z_match_find(Str* restrict target, char* restrict cwd, size_t cwd_length,
                           z_Database* restrict db, Arena* restrict scratch_arena);
 
-enum z_Result z_database_add(char* restrict path, size_t path_length, char* restrict cwd, size_t cwd_length,
+enum z_Result z_database_add(Str* restrict path, char* restrict cwd, size_t cwd_length,
                              z_Database* restrict db, Arena* restrict arena);
 
 // read from empty database file
@@ -55,7 +55,7 @@ void z_read_non_empty_database_test()
         eassert(false);
     }
 
-    z_Directory* match = z_match_find(new_value.value, new_value.length, cwd, strlen(cwd) + 1, &db, &scratch_arena);
+    z_Directory* match = z_match_find(&new_value, cwd, strlen(cwd) + 1, &db, &scratch_arena);
     eassert(match != NULL);
     eassert(db.count == 1);
     eassert(match->path_length == 57);
@@ -83,7 +83,7 @@ void z_add_to_database_empty_database_test()
     strcpy(new_value.value, "ncsh");
     Str cwd = {.value = "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", .length = 52};
 
-    eassert(z_database_add(new_value.value, new_value.length, cwd.value, cwd.length, &db, &arena) == Z_SUCCESS);
+    eassert(z_database_add(&new_value, cwd.value, cwd.length, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
     eassert(db.dirs[0].path_length == 57);
     eassert(memcmp(db.dirs[0].path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh", 57) == 0);
@@ -102,10 +102,11 @@ void z_add_new_entry_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 0);
 
-    eassert(z_add("/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", 52, &db, &arena) == Z_SUCCESS);
+    Str path = Str_New_Literal("/mnt/c/Users/Alex/source/repos/PersonalRepos/shells");
+    eassert(z_add(&path, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
-    eassert(db.dirs[0].path_length == 52);
-    eassert(memcmp(db.dirs[0].path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", 52) == 0);
+    eassert(db.dirs[0].path_length == path.length);
+    eassert(memcmp(db.dirs[0].path, path.value, path.length) == 0);
 
     z_exit(&db);
     ARENA_TEST_TEARDOWN;
@@ -121,10 +122,11 @@ void z_add_existing_in_database_new_entry()
     eassert(db.count == 1);
 
     double initial_rank = db.dirs[0].rank;
-    eassert(z_add("/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", 52, &db, &arena) == Z_SUCCESS);
+    Str path = Str_New_Literal("/mnt/c/Users/Alex/source/repos/PersonalRepos/shells");
+    eassert(z_add(&path, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
-    eassert(db.dirs[0].path_length == 52);
-    eassert(memcmp(db.dirs[0].path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", 52) == 0);
+    eassert(db.dirs[0].path_length == path.length);
+    eassert(memcmp(db.dirs[0].path, path.value, 52) == 0);
     eassert(db.dirs[0].rank > initial_rank);
 
     z_exit(&db);
@@ -140,9 +142,9 @@ void z_add_null_parameters()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
 
-    eassert(z_add(NULL, 0, &db, &arena) == Z_NULL_REFERENCE);
-    eassert(z_add(NULL, 3, &db, &arena) == Z_NULL_REFERENCE);
-    eassert(z_add("..", 3, NULL, &arena) == Z_NULL_REFERENCE);
+    eassert(z_add(&Str_Empty, &db, &arena) == Z_NULL_REFERENCE);
+    eassert(z_add(&Str_New(NULL, 3), &db, &arena) == Z_NULL_REFERENCE);
+    eassert(z_add(&Str_New("..", 3), NULL, &arena) == Z_NULL_REFERENCE);
 
     z_exit(&db);
     ARENA_TEST_TEARDOWN;
@@ -157,10 +159,10 @@ void z_add_bad_parameters()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
 
-    eassert(z_add(".", 0, &db, &arena) == Z_BAD_STRING);
-    eassert(z_add(".", 1, &db, &arena) == Z_BAD_STRING);
-    eassert(z_add("..", 1, &db, &arena) == Z_BAD_STRING);
-    eassert(z_add("..", 2, &db, &arena) == Z_BAD_STRING);
+    eassert(z_add(&Str_New(".", 0), &db, &arena) == Z_BAD_STRING);
+    eassert(z_add(&Str_New(".", 1), &db, &arena) == Z_BAD_STRING);
+    eassert(z_add(&Str_New("..", 1), &db, &arena) == Z_BAD_STRING);
+    eassert(z_add(&Str_New("..", 2), &db, &arena) == Z_BAD_STRING);
 
     z_exit(&db);
     ARENA_TEST_TEARDOWN;
@@ -173,11 +175,12 @@ void z_add_new_entry_contained_in_another_entry_but_different_test()
     z_Database db = {0};
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
+    Str path = Str_New_Literal("/mnt/c/Users/Alex/source/repos/PersonalRepos");
 
-    eassert(z_add("/mnt/c/Users/Alex/source/repos/PersonalRepos", 45, &db, &arena) == Z_SUCCESS);
+    eassert(z_add(&path, &db, &arena) == Z_SUCCESS);
 
     eassert(db.count == 2);
-    eassert(db.dirs[1].path_length == 45);
+    eassert(db.dirs[1].path_length == path.length);
 
     z_exit(&db);
     ARENA_TEST_TEARDOWN;
@@ -194,14 +197,14 @@ void z_match_find_empty_database_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 0);
 
-    Str target = {.value = "path", .length = 5};
+    Str target = Str_New_Literal("path");
     char cwd[CWD_LENGTH];
     if (!getcwd(cwd, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
         eassert(false);
     }
 
-    z_Directory* result = z_match_find(target.value, target.length, cwd, strlen(cwd) + 1, &db, &scratch_arena);
+    z_Directory* result = z_match_find(&target, cwd, strlen(cwd) + 1, &db, &scratch_arena);
     eassert(result == NULL);
 
     ARENA_TEST_TEARDOWN;
@@ -218,15 +221,13 @@ void z_write_empty_database_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 0);
 
-    Str new_value = {.length = 5};
-    new_value.value = arena_malloc(&arena, new_value.length, char);
-    strcpy(new_value.value, "ncsh");
+    Str new_value = Str_New_Literal("ncsh");
     Str cwd = {.value = "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", .length = 52};
 
-    eassert(z_database_add(new_value.value, new_value.length, cwd.value, cwd.length, &db, &arena) == Z_SUCCESS);
+    eassert(z_database_add(&new_value, cwd.value, cwd.length, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 1);
-    eassert(db.dirs[0].path_length == 57);
-    eassert(memcmp(db.dirs[0].path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh", 57) == 0);
+    eassert(db.dirs[0].path_length == new_value.length + cwd.length);
+    eassert(memcmp(db.dirs[0].path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh", new_value.length + cwd.length) == 0);
     eassert(db.dirs[0].rank > 0 && db.dirs[0].last_accessed > 0);
 
     eassert(z_exit(&db) == Z_SUCCESS);
@@ -244,7 +245,7 @@ void z_add_to_database_empty_value_test()
     eassert(db.count == 1);
     Str cwd = {.value = "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells", .length = 52};
 
-    eassert(z_database_add(Str_Empty.value, Str_Empty.length, cwd.value, cwd.length, &db, &arena) == Z_NULL_REFERENCE);
+    eassert(z_database_add(&Str_Empty, cwd.value, cwd.length, &db, &arena) == Z_NULL_REFERENCE);
     eassert(db.count == 1);
 
     ARENA_TEST_TEARDOWN;
@@ -260,12 +261,10 @@ void z_write_nonempty_database_test()
     eassert(db.count == 1);
 
     double start_rank = db.dirs[0].rank;
-    Str new_value = {.length = 9};
-    new_value.value = arena_malloc(&arena, new_value.length, char);
-    strcpy(new_value.value, "ttytest2");
+    Str new_value = Str_New_Literal("ttytest2");
     Str cwd = {.value = "/mnt/c/Users/Alex/source/repos/PersonalRepos", .length = 45};
 
-    eassert(z_database_add(new_value.value, new_value.length, cwd.value, cwd.length, &db, &arena) == Z_SUCCESS);
+    eassert(z_database_add(&new_value, cwd.value, cwd.length, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 2);
     eassert(db.dirs[0].path_length == 57);
     eassert(db.dirs[0].rank == start_rank);
@@ -286,17 +285,17 @@ void z_match_find_finds_exact_match_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 2);
 
-    Str target = {.value = "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh", .length = 57};
+    Str target = Str_New_Literal("/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh");
     char cwd[CWD_LENGTH];
     if (!getcwd(cwd, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
         eassert(false);
     }
 
-    z_Directory* result = z_match_find(target.value, target.length, cwd, strlen(cwd) + 1, &db, &scratch_arena);
+    z_Directory* result = z_match_find(&target, cwd, strlen(cwd) + 1, &db, &scratch_arena);
     eassert(result != NULL);
     eassert(result->path_length == 57);
-    eassert(memcmp(result->path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh", 57) == 0);
+    eassert(memcmp(result->path, target.value, target.length) == 0);
     eassert(result->rank > 0 && result->last_accessed > 0);
 
     ARENA_TEST_TEARDOWN;
@@ -313,14 +312,14 @@ void z_match_find_finds_match_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 2);
 
-    Str target = {.value = "ncsh", .length = 5};
+    Str target = Str_New_Literal("ncsh");
     char cwd[CWD_LENGTH];
     if (!getcwd(cwd, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
         eassert(false);
     }
 
-    z_Directory* result = z_match_find(target.value, target.length, cwd, strlen(cwd) + 1, &db, &scratch_arena);
+    z_Directory* result = z_match_find(&target, cwd, strlen(cwd) + 1, &db, &scratch_arena);
     eassert(result != NULL);
     eassert(result->path_length == 57);
     eassert(memcmp(result->path, "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells/ncsh", 57) == 0);
@@ -340,13 +339,13 @@ void z_match_find_no_match_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 2);
 
-    Str target = {.value = "path", .length = 5};
+    Str target = Str_New_Literal("ncsh");
     char cwd[CWD_LENGTH];
     if (!getcwd(cwd, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
         eassert(false);
     }
-    z_Directory* result = z_match_find(target.value, target.length, cwd, strlen(cwd) + 1, &db, &scratch_arena);
+    z_Directory* result = z_match_find(&target, cwd, strlen(cwd) + 1, &db, &scratch_arena);
     if (result)
         printf("result: %s\n", result->path);
     eassert(result == NULL);
@@ -365,13 +364,13 @@ void z_match_find_multiple_matches_test()
     eassert(z_init(&config_location, &db, &arena) == Z_SUCCESS);
     eassert(db.count == 2);
 
-    Str target = {.value = "PersonalRepos", .length = 14};
+    Str target = Str_New_Literal("PersonalRepos");
     char cwd[CWD_LENGTH];
     if (!getcwd(cwd, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
         eassert(false);
     }
-    z_Directory* result = z_match_find(target.value, target.length, cwd, strlen(cwd) + 1, &db, &scratch_arena);
+    z_Directory* result = z_match_find(&target, cwd, strlen(cwd) + 1, &db, &scratch_arena);
     eassert(result != NULL);
     eassert(result->path_length == 57);
 
@@ -397,8 +396,8 @@ void z_change_directory_test()
         eassert(false);
     }
 
-    Str target = {.value = "ncsh", .length = 5};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("ncsh");
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -436,7 +435,7 @@ void z_home_empty_target_change_directory_test()
     }
 
     Str target = Str_Empty;
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -476,8 +475,8 @@ void z_no_match_change_directory_test()
         eassert(false);
     }
 
-    Str target = {.value = "zzz", .length = 4};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("zzz");
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -516,8 +515,8 @@ void z_valid_subdirectory_change_directory_test()
         eassert(false);
     }
 
-    Str target = {.value = "tests", .length = 6};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("tests");
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -557,10 +556,10 @@ void z_dir_slash_dir_change_directory_test()
         eassert(false);
     }
     size_t buffer_length = strlen(buffer) + 1;
-    Str target = {.value = "tests/test_dir", .length = 15};
-    z_database_add(target.value, target.length, buffer, buffer_length, &db, &arena);
+    Str target = Str_New_Literal("tests/test_dir");
+    z_database_add(&target, buffer, buffer_length, &db, &arena);
 
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -602,8 +601,8 @@ void z_double_dot_change_directory_test()
         eassert(false);
     }
 
-    Str target = {.value = "..", .length = 3};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("..");
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -644,8 +643,8 @@ void z_empty_database_valid_subdirectory_change_directory_test()
         eassert(false);
     }
 
-    Str target = {.value = "tests", .length = 6};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("tests");
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
         ARENA_TEST_TEARDOWN;
@@ -688,8 +687,8 @@ void z_contains_correct_match_test()
         eassert(false);
     }
 
-    Str target = {.value = "PersonalRepos", .length = 14};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("PersonalRepos");
+    z(&target, buffer, &db, &arena, scratch_arena);
     char* path = "/mnt/c/Users/Alex/source/repos/PersonalRepos/shells";
 
     if (!getcwd(buffer_after, CWD_LENGTH)) {
@@ -722,8 +721,8 @@ void z_crashing_input_test()
     eassert(db.count == 2);
 
     char* buffer = arena_malloc(&arena, CWD_LENGTH, char);
-    Str target = {.value = "", .length = sizeof("")};
-    z(target.value, target.length, buffer, &db, &arena, scratch_arena);
+    Str target = Str_New_Literal("");
+    z(&target, buffer, &db, &arena, scratch_arena);
 
     // not crashing is a test passed
 


### PR DESCRIPTION
char* value and size_t length used in many places. The shell has a lot of string processing and manipulation. Expand available str.h functions and usage of Str instead of passing around the value and length separately. Using Str everywhere simplifies str.h and allows the functions to be used in more places.